### PR TITLE
Transfer from hub to dst implemented : fixes #32

### DIFF
--- a/DEHPMatlab.Tests/ViewModel/DstDataSourceViewModelTestFixture.cs
+++ b/DEHPMatlab.Tests/ViewModel/DstDataSourceViewModelTestFixture.cs
@@ -109,9 +109,15 @@ namespace DEHPMatlab.Tests.ViewModel
             this.hubMapResult.Add(new ParameterToMatlabVariableMappingRowViewModel());
             Assert.DoesNotThrow(() => this.viewModel.ConnectCommand.Execute(null));
 
+            this.navigationService.Setup(x => x.ShowDxDialog<LogoutConfirmDialog>()).Returns(false);
+            Assert.DoesNotThrow(() => this.viewModel.ConnectCommand.Execute(null));
+
+            this.navigationService.Setup(x => x.ShowDxDialog<LogoutConfirmDialog>()).Returns(true);
+            Assert.DoesNotThrow(() => this.viewModel.ConnectCommand.Execute(null));
+
             this.dstController.Setup(x => x.IsSessionOpen).Returns(false);
             Assert.DoesNotThrow(() => this.viewModel.ConnectCommand.Execute(null));
-            this.dstController.Verify(x => x.Disconnect(), Times.Exactly(3));
+            this.dstController.Verify(x => x.Disconnect(), Times.Exactly(4));
         }
     }
 }

--- a/DEHPMatlab.Tests/ViewModel/DstDataSourceViewModelTestFixture.cs
+++ b/DEHPMatlab.Tests/ViewModel/DstDataSourceViewModelTestFixture.cs
@@ -26,6 +26,8 @@ namespace DEHPMatlab.Tests.ViewModel
 {
     using System.Reactive.Concurrency;
 
+    using CDP4Common.EngineeringModelData;
+
     using DEHPCommon.HubController.Interfaces;
     using DEHPCommon.Services.NavigationService;
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
@@ -33,6 +35,8 @@ namespace DEHPMatlab.Tests.ViewModel
     using DEHPMatlab.DstController;
     using DEHPMatlab.ViewModel;
     using DEHPMatlab.ViewModel.Interfaces;
+    using DEHPMatlab.ViewModel.Row;
+    using DEHPMatlab.Views.Dialogs;
 
     using Moq;
 
@@ -50,14 +54,22 @@ namespace DEHPMatlab.Tests.ViewModel
         private Mock<IStatusBarControlViewModel> statusBar;
         private Mock<IDstBrowserHeaderViewModel> dstBrowserHeader;
         private Mock<IDstVariablesControlViewModel> dstVariablesControl;
+        private ReactiveList<ElementBase> dstMapResult;
+        private ReactiveList<ParameterToMatlabVariableMappingRowViewModel> hubMapResult;
 
         [SetUp]
         public void Setup()
         {
+            RxApp.MainThreadScheduler = Scheduler.CurrentThread;
             this.navigationService = new Mock<INavigationService>();
+
+            this.dstMapResult = new ReactiveList<ElementBase>();
+            this.hubMapResult = new ReactiveList<ParameterToMatlabVariableMappingRowViewModel>();
 
             this.dstController = new Mock<IDstController>();
             this.dstController.Setup(x => x.IsSessionOpen).Returns(true);
+            this.dstController.Setup(x => x.DstMapResult).Returns(this.dstMapResult);
+            this.dstController.Setup(x => x.HubMapResult).Returns(this.hubMapResult);
 
             this.hubController = new Mock<IHubController>();
             this.statusBar = new Mock<IStatusBarControlViewModel>();
@@ -83,9 +95,23 @@ namespace DEHPMatlab.Tests.ViewModel
         {
             Assert.IsTrue(this.viewModel.ConnectCommand.CanExecute(null));
             Assert.AreEqual("Disconnect", this.viewModel.ConnectButtonText);
+            
             Assert.DoesNotThrow(() => this.viewModel.ConnectCommand.Execute(null));
+
+            this.dstMapResult.Add(new ElementDefinition());
+            this.navigationService.Setup(x => x.ShowDxDialog<LogoutConfirmDialog>()).Returns(false);
+            Assert.DoesNotThrow(() => this.viewModel.ConnectCommand.Execute(null));
+
+            this.navigationService.Setup(x => x.ShowDxDialog<LogoutConfirmDialog>()).Returns(true);
+            Assert.DoesNotThrow(() => this.viewModel.ConnectCommand.Execute(null));
+
+            this.dstMapResult.Clear();
+            this.hubMapResult.Add(new ParameterToMatlabVariableMappingRowViewModel());
+            Assert.DoesNotThrow(() => this.viewModel.ConnectCommand.Execute(null));
+
             this.dstController.Setup(x => x.IsSessionOpen).Returns(false);
             Assert.DoesNotThrow(() => this.viewModel.ConnectCommand.Execute(null));
+            this.dstController.Verify(x => x.Disconnect(), Times.Exactly(3));
         }
     }
 }

--- a/DEHPMatlab.Tests/ViewModel/HubDataSourceViewModelTestFixture.cs
+++ b/DEHPMatlab.Tests/ViewModel/HubDataSourceViewModelTestFixture.cs
@@ -249,12 +249,14 @@ namespace DEHPMatlab.Tests.ViewModel
                 new DomainOfExpertise(), this.session.Object, null);
 
             var parameterRow = new ParameterRowViewModel(parameter, this.session.Object, elementRow);
+            var parameterRow2 = new ParameterRowViewModel(parameter, this.session.Object, null);
 
             this.viewModel.ObjectBrowser.SelectedThings.Add(
                 elementRow);
 
             this.viewModel.ObjectBrowser.SelectedThing = parameter;
             this.viewModel.ObjectBrowser.SelectedThings.Add(parameterRow);
+            this.viewModel.ObjectBrowser.SelectedThings.Add(parameterRow2);
 
             Assert.IsTrue(this.viewModel.ObjectBrowser.MapCommand.CanExecute(null));
             Assert.DoesNotThrow(() => this.viewModel.ObjectBrowser.MapCommand.Execute(null));

--- a/DEHPMatlab.Tests/ViewModel/HubDataSourceViewModelTestFixture.cs
+++ b/DEHPMatlab.Tests/ViewModel/HubDataSourceViewModelTestFixture.cs
@@ -33,11 +33,13 @@ namespace DEHPMatlab.Tests.ViewModel
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
 
     using CDP4Dal;
     using CDP4Dal.Permission;
 
     using DEHPCommon;
+    using DEHPCommon.Enumerators;
     using DEHPCommon.HubController.Interfaces;
     using DEHPCommon.Services.NavigationService;
     using DEHPCommon.UserInterfaces.ViewModels;
@@ -49,6 +51,7 @@ namespace DEHPMatlab.Tests.ViewModel
     using DEHPMatlab.DstController;
     using DEHPMatlab.ViewModel;
     using DEHPMatlab.ViewModel.Dialogs.Interfaces;
+    using DEHPMatlab.ViewModel.Row;
     using DEHPMatlab.Views.Dialogs;
 
     using Moq;
@@ -74,11 +77,17 @@ namespace DEHPMatlab.Tests.ViewModel
         private Person person;
         private Participant participant;
         private Iteration iteration;
+        private ReactiveList<ElementBase> dstMapResult;
+        private ReactiveList<ParameterToMatlabVariableMappingRowViewModel> hubMapResult;
 
         [SetUp]
         public void Setup()
         {
             RxApp.MainThreadScheduler = Scheduler.CurrentThread;
+
+            this.dstMapResult = new ReactiveList<ElementBase>();
+            this.hubMapResult = new ReactiveList<ParameterToMatlabVariableMappingRowViewModel>();
+
             this.navigationService = new Mock<INavigationService>();
             this.navigationService.Setup(x => x.ShowDialog<Login>());
 
@@ -148,6 +157,10 @@ namespace DEHPMatlab.Tests.ViewModel
             this.objectBrowser.Setup(x => x.Things).Returns(new ReactiveList<BrowserViewModelBase>());
             this.objectBrowser.Setup(x => x.SelectedThings).Returns(new ReactiveList<object>());
 
+            this.dstController.Setup(x => x.DstMapResult).Returns(this.dstMapResult);
+            this.dstController.Setup(x => x.HubMapResult).Returns(this.hubMapResult);
+            this.dstController.Setup(x => x.ClearMappingCollections());
+
             this.publicationBrowser = new Mock<IPublicationBrowserViewModel>();
             this.hubBrowserHeader = new Mock<IHubBrowserHeaderViewModel>();
             this.sessionControl = new Mock<IHubSessionControlViewModel>();
@@ -176,10 +189,27 @@ namespace DEHPMatlab.Tests.ViewModel
             Assert.IsTrue(this.viewModel.ConnectCommand.CanExecute(null));
             this.hubController.Setup(x => x.IsSessionOpen).Returns(true);
             this.viewModel.ConnectCommand.Execute(null);
+
+            this.dstMapResult.Add(new ElementDefinition());
+            this.navigationService.Setup(x => x.ShowDxDialog<LogoutConfirmDialog>()).Returns(false);
+            this.viewModel.ConnectCommand.Execute(null);
+
+            this.navigationService.Setup(x => x.ShowDxDialog<LogoutConfirmDialog>()).Returns(true);
+            this.viewModel.ConnectCommand.Execute(null);
+
+            this.viewModel.UpdateStatusBar(true);
+
+            this.statusBar.Verify(x => x.Append(It.IsAny<string>(),
+                StatusBarMessageSeverity.Info), Times.Once);
+
+            this.dstMapResult.Clear();
+            this.hubMapResult.Add(new ParameterToMatlabVariableMappingRowViewModel());
+            this.viewModel.ConnectCommand.Execute(null);
+
             this.hubController.Setup(x => x.IsSessionOpen).Returns(false);
             this.hubController.Setup(x => x.OpenIteration).Returns((Iteration)null);
             this.viewModel.ConnectCommand.Execute(null);
-            this.hubController.Verify(x => x.Close(), Times.Once);
+            this.hubController.Verify(x => x.Close(), Times.Exactly(3));
             this.navigationService.Verify(x => x.ShowDialog<Login>(), Times.Once);
         }
 
@@ -199,16 +229,18 @@ namespace DEHPMatlab.Tests.ViewModel
             this.objectBrowser.Setup(x => x.SelectedThings)
                 .Returns(new ReactiveList<object>());
 
+            var parameter = new Parameter(Guid.NewGuid(), null, new Uri("t://s.t"))
+            {
+                ParameterType = new DateTimeParameterType(Guid.NewGuid(), null, new Uri("t://s.t")),
+                ValueSet = { new ParameterValueSet(Guid.NewGuid(), null, new Uri("t://s.t")) }
+            };
+
             var elementDefinition = new ElementDefinition(Guid.NewGuid(), null, new Uri("t://s.t"))
             {
-                Parameter =
+                Parameter = 
                 {
-                    new Parameter(Guid.NewGuid(), null, new Uri("t://s.t"))
-                    {
-                        ParameterType = new DateTimeParameterType(Guid.NewGuid(), null, new Uri("t://s.t")),
-                        ValueSet = { new ParameterValueSet(Guid.NewGuid(), null, new Uri("t://s.t")) }
-                    }
-                }
+                    parameter
+                } 
             };
 
             this.iteration.Element.Add(elementDefinition);
@@ -216,8 +248,13 @@ namespace DEHPMatlab.Tests.ViewModel
             var elementRow = new ElementDefinitionRowViewModel(elementDefinition,
                 new DomainOfExpertise(), this.session.Object, null);
 
+            var parameterRow = new ParameterRowViewModel(parameter, this.session.Object, elementRow);
+
             this.viewModel.ObjectBrowser.SelectedThings.Add(
                 elementRow);
+
+            this.viewModel.ObjectBrowser.SelectedThing = parameter;
+            this.viewModel.ObjectBrowser.SelectedThings.Add(parameterRow);
 
             Assert.IsTrue(this.viewModel.ObjectBrowser.MapCommand.CanExecute(null));
             Assert.DoesNotThrow(() => this.viewModel.ObjectBrowser.MapCommand.Execute(null));

--- a/DEHPMatlab.Tests/ViewModel/MappingViewModelTestFixture.cs
+++ b/DEHPMatlab.Tests/ViewModel/MappingViewModelTestFixture.cs
@@ -186,12 +186,14 @@ namespace DEHPMatlab.Tests.ViewModel
             this.dstMapResult.Clear();
             Assert.AreEqual(0, this.viewModel.MappingRows.Count);
 
-            this.hubMapResult.Add(new ParameterToMatlabVariableMappingRowViewModel()
+            var toAdd = new ParameterToMatlabVariableMappingRowViewModel()
             {
                 SelectedParameter = this.parameter0,
                 SelectedMatlabVariable = new MatlabWorkspaceRowViewModel("a", 0),
-                SelectedValue = new ValueSetValueRowViewModel(this.parameter0.QueryParameterBaseValueSet(null,null), "8", null)
-            });
+                SelectedValue = new ValueSetValueRowViewModel(this.parameter0.QueryParameterBaseValueSet(null, null), "8", null)
+            };
+
+            this.hubMapResult.Add(toAdd);
 
             Assert.AreEqual(1, this.viewModel.MappingRows.Count);
 
@@ -204,6 +206,8 @@ namespace DEHPMatlab.Tests.ViewModel
             Assert.AreEqual(180, this.viewModel.MappingRows.First().ArrowDirection);
             Assert.AreEqual(0, this.viewModel.MappingRows.First().DstThing.GridColumnIndex);
             Assert.AreEqual(2, this.viewModel.MappingRows.First().HubThing.GridColumnIndex);
+
+            this.hubMapResult.Add(toAdd);
 
             this.hubMapResult.Clear();
             this.dstMapResult.Clear();

--- a/DEHPMatlab.Tests/ViewModel/MappingViewModelTestFixture.cs
+++ b/DEHPMatlab.Tests/ViewModel/MappingViewModelTestFixture.cs
@@ -52,6 +52,7 @@ namespace DEHPMatlab.Tests.ViewModel
         private Mock<IDstController> dstController;
         private Mock<IHubController> hubController;
         private ReactiveList<ElementBase> dstMapResult;
+        private ReactiveList<ParameterToMatlabVariableMappingRowViewModel> hubMapResult;
         private ElementDefinition element0;
         private Parameter parameter0;
         private Parameter parameter1;
@@ -140,9 +141,12 @@ namespace DEHPMatlab.Tests.ViewModel
             this.hubController.Setup(x => x.OpenIteration).Returns(this.iteration);
 
             this.dstMapResult = new ReactiveList<ElementBase>();
+            this.hubMapResult = new ReactiveList<ParameterToMatlabVariableMappingRowViewModel>();
+
             this.dstController = new Mock<IDstController>();
             this.dstController.Setup(x => x.MappingDirection).Returns(MappingDirection.FromDstToHub);
             this.dstController.Setup(x => x.DstMapResult).Returns(this.dstMapResult);
+            this.dstController.Setup(x => x.HubMapResult).Returns(this.hubMapResult);
 
             this.dstController.Setup(x => x.ParameterVariable).Returns(new Dictionary<ParameterOrOverrideBase, MatlabWorkspaceRowViewModel>()
             {
@@ -167,15 +171,44 @@ namespace DEHPMatlab.Tests.ViewModel
             
             this.dstMapResult.Add(this.elementUsage);
             Assert.AreEqual(1, this.viewModel.MappingRows.Count);
+            Assert.IsNotNull(this.viewModel.MappingRows.First().DstThing.Value);
 
             this.viewModel.UpdateMappingRowsDirection(MappingDirection.FromHubToDst);
             Assert.AreEqual(180, this.viewModel.MappingRows.First().ArrowDirection);
+            Assert.AreEqual(2, this.viewModel.MappingRows.First().DstThing.GridColumnIndex);
+            Assert.AreEqual(0, this.viewModel.MappingRows.First().HubThing.GridColumnIndex);
 
             this.viewModel.UpdateMappingRowsDirection(MappingDirection.FromDstToHub);
             Assert.AreEqual(0, this.viewModel.MappingRows.First().ArrowDirection);
+            Assert.AreEqual(0, this.viewModel.MappingRows.First().DstThing.GridColumnIndex);
+            Assert.AreEqual(2, this.viewModel.MappingRows.First().HubThing.GridColumnIndex);
 
             this.dstMapResult.Clear();
             Assert.AreEqual(0, this.viewModel.MappingRows.Count);
+
+            this.hubMapResult.Add(new ParameterToMatlabVariableMappingRowViewModel()
+            {
+                SelectedParameter = this.parameter0,
+                SelectedMatlabVariable = new MatlabWorkspaceRowViewModel("a", 0),
+                SelectedValue = new ValueSetValueRowViewModel(this.parameter0.QueryParameterBaseValueSet(null,null), "8", null)
+            });
+
+            Assert.AreEqual(1, this.viewModel.MappingRows.Count);
+
+            this.viewModel.UpdateMappingRowsDirection(MappingDirection.FromHubToDst);
+            Assert.AreEqual(0, this.viewModel.MappingRows.First().ArrowDirection);
+            Assert.AreEqual(2, this.viewModel.MappingRows.First().DstThing.GridColumnIndex);
+            Assert.AreEqual(0, this.viewModel.MappingRows.First().HubThing.GridColumnIndex);
+
+            this.viewModel.UpdateMappingRowsDirection(MappingDirection.FromDstToHub);
+            Assert.AreEqual(180, this.viewModel.MappingRows.First().ArrowDirection);
+            Assert.AreEqual(0, this.viewModel.MappingRows.First().DstThing.GridColumnIndex);
+            Assert.AreEqual(2, this.viewModel.MappingRows.First().HubThing.GridColumnIndex);
+
+            this.hubMapResult.Clear();
+            this.dstMapResult.Clear();
+
+            Assert.IsEmpty(this.viewModel.MappingRows);
         }
     }
 }

--- a/DEHPMatlab/DstController/IDstController.cs
+++ b/DEHPMatlab/DstController/IDstController.cs
@@ -93,9 +93,19 @@ namespace DEHPMatlab.DstController
         Dictionary<ParameterOrOverrideBase, MatlabWorkspaceRowViewModel> ParameterVariable { get; }
 
         /// <summary>
-        /// Gets the colection of <see cref="ElementBase"/> that are selected to be transfered
+        /// Gets the collection of <see cref="ElementBase"/> that are selected to be transfered
         /// </summary>
         ReactiveList<ElementBase> SelectedDstMapResultToTransfer { get; }
+
+        /// <summary>
+        /// Gets the collection of <see cref="ParameterToMatlabVariableMappingRowViewModel"/> that are selected to be transfered
+        /// </summary>
+        ReactiveList<ParameterToMatlabVariableMappingRowViewModel> SelectedHubMapResultToTransfer { get; }
+
+        /// <summary>
+        /// Clears all collections containing mapped elements for any direction
+        /// </summary>
+        void ClearMappingCollections();
 
         /// <summary>
         /// Connects the adapter to a Matlab Instance
@@ -146,5 +156,11 @@ namespace DEHPMatlab.DstController
         /// </summary>
         /// <returns>A <see cref="Task"/></returns>
         Task TransferMappedThingsToHub();
+
+        /// <summary>
+        /// Transfers the mapped <see cref="ElementBase"/> to the Dst data source
+        /// </summary>
+        /// <returns>A <see cref="Task"/></returns>
+        Task TransferMappedThingsToDst();
     }
 }

--- a/DEHPMatlab/MappingRules/ElementDefinitionToMatlabVariableRule.cs
+++ b/DEHPMatlab/MappingRules/ElementDefinitionToMatlabVariableRule.cs
@@ -51,7 +51,7 @@ namespace DEHPMatlab.MappingRules
         {
             return input.Select(x =>
             {
-                x.SelectedMatlabVariable = new MatlabWorkspaceRowViewModel(x.SelectedMatlabVariable.Name, x.SelectedValue.Value)
+                x.SelectedMatlabVariable = new MatlabWorkspaceRowViewModel(x.SelectedMatlabVariable.Name, x.SelectedMatlabVariable.Value)
                 {
                     ParentName = x.SelectedMatlabVariable.ParentName,
                 };

--- a/DEHPMatlab/MappingRules/MatlabVariableToElementDefinitionRule.cs
+++ b/DEHPMatlab/MappingRules/MatlabVariableToElementDefinitionRule.cs
@@ -81,6 +81,7 @@ namespace DEHPMatlab.MappingRules
             try
             {
                 this.owner = this.hubController.CurrentDomainOfExpertise;
+                this.parameterNodeIdIdentifier.Clear();
 
                 foreach (var matlabVariable in input)
                 {

--- a/DEHPMatlab/ViewModel/DataSourceViewModel.cs
+++ b/DEHPMatlab/ViewModel/DataSourceViewModel.cs
@@ -138,7 +138,7 @@ namespace DEHPMatlab.ViewModel
         /// Append the connection status to the status bar
         /// </summary>
         /// <param name="isSessionOpen">Assert whether the status bar should update as connected or disconnected</param>
-        protected void UpdateStatusBar(bool isSessionOpen)
+        public void UpdateStatusBar(bool isSessionOpen)
         {
             if (!this.canLogToStatusBar)
             {

--- a/DEHPMatlab/ViewModel/Dialogs/HubMappingConfigurationDialogViewModel.cs
+++ b/DEHPMatlab/ViewModel/Dialogs/HubMappingConfigurationDialogViewModel.cs
@@ -95,8 +95,8 @@ namespace DEHPMatlab.ViewModel.Dialogs
         public HubMappingConfigurationDialogViewModel(IHubController hubController, IDstController dstController,
             IStatusBarControlViewModel statusBar) : base(hubController, dstController, statusBar)
         {
-            this.UpdateProperties();
             this.InitializesCommandsAndObservables();
+            this.UpdateProperties();
         }
 
         /// <summary>

--- a/DEHPMatlab/ViewModel/DstDataSourceViewModel.cs
+++ b/DEHPMatlab/ViewModel/DstDataSourceViewModel.cs
@@ -33,6 +33,7 @@ namespace DEHPMatlab.ViewModel
     using ReactiveUI;
 
     using System;
+    using System.Linq;
     using System.Reactive.Linq;
 
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
@@ -117,7 +118,13 @@ namespace DEHPMatlab.ViewModel
 
             if (this.dstController.IsSessionOpen)
             {
-                this.dstController.Disconnect();
+                if (((this.dstController.DstMapResult.Any() || this.dstController.HubMapResult.Any())
+                     && this.NavigationService.ShowDxDialog<LogoutConfirmDialog>() is true)
+                    || (!this.dstController.DstMapResult.Any() && !this.dstController.HubMapResult.Any()))
+                {
+                    this.dstController.ClearMappingCollections();
+                    this.dstController.Disconnect();
+                }
             }
             else
             {

--- a/DEHPMatlab/ViewModel/HubDataSourceViewModel.cs
+++ b/DEHPMatlab/ViewModel/HubDataSourceViewModel.cs
@@ -146,7 +146,7 @@ namespace DEHPMatlab.ViewModel
                 }
             }
 
-            viewModel.Elements.AddRange(rows.ToList()
+            viewModel.Elements.AddRange(rows
                 .Select(x =>
                 {
                     x.Thing.Clone(true);

--- a/DEHPMatlab/ViewModel/MatlabTransferControlViewModel.cs
+++ b/DEHPMatlab/ViewModel/MatlabTransferControlViewModel.cs
@@ -30,8 +30,6 @@ namespace DEHPMatlab.ViewModel
     using System.Reactive.Linq;
     using System.Threading.Tasks;
 
-    using CDP4Common.EngineeringModelData;
-
     using CDP4Dal;
 
     using DEHPCommon.Enumerators;
@@ -120,12 +118,9 @@ namespace DEHPMatlab.ViewModel
         /// </summary>
         public void UpdateNumberOfThingsToTransfer()
         {
-            this.NumberOfThing = this.dstController.MappingDirection switch
-            {
-                MappingDirection.FromDstToHub => this.dstController.SelectedDstMapResultToTransfer.OfType<ElementDefinition>().SelectMany(x => x.Parameter).Count()
-                                                 + this.dstController.SelectedDstMapResultToTransfer.OfType<ElementUsage>().SelectMany(x => x.ParameterOverride).Count(),
-                _ => 0
-            };
+            this.NumberOfThing = this.dstController.MappingDirection == MappingDirection.FromDstToHub
+                ? this.dstController.SelectedDstMapResultToTransfer.Count()
+                : this.dstController.SelectedHubMapResultToTransfer.Count;
 
             this.CanTransfer = this.NumberOfThing > 0;
         }
@@ -137,6 +132,8 @@ namespace DEHPMatlab.ViewModel
         private async Task CancelTransfer()
         {
             this.dstController.DstMapResult.Clear();
+            this.dstController.HubMapResult.Clear();
+            this.dstController.ParameterVariable.Clear();
             this.exchangeHistoryService.ClearPending();
             await Task.Delay(1);
             this.TransferInProgress = false;
@@ -151,6 +148,8 @@ namespace DEHPMatlab.ViewModel
         private void InitializesCommandsAndObservables()
         {
             this.dstController.SelectedDstMapResultToTransfer.CountChanged.Subscribe(_ => this.UpdateNumberOfThingsToTransfer());
+            
+            this.dstController.SelectedHubMapResultToTransfer.CountChanged.Subscribe(_ => this.UpdateNumberOfThingsToTransfer());
 
             this.WhenAnyValue(x => x.dstController.MappingDirection)
                 .Subscribe(_ => this.UpdateNumberOfThingsToTransfer());
@@ -188,6 +187,10 @@ namespace DEHPMatlab.ViewModel
             if (this.dstController.MappingDirection is MappingDirection.FromDstToHub)
             {
                 await this.dstController.TransferMappedThingsToHub();
+            }
+            else
+            {
+                await this.dstController.TransferMappedThingsToDst();
             }
 
             await this.exchangeHistoryService.Write();

--- a/DEHPMatlab/ViewModel/MatlabTransferControlViewModel.cs
+++ b/DEHPMatlab/ViewModel/MatlabTransferControlViewModel.cs
@@ -119,7 +119,7 @@ namespace DEHPMatlab.ViewModel
         public void UpdateNumberOfThingsToTransfer()
         {
             this.NumberOfThing = this.dstController.MappingDirection == MappingDirection.FromDstToHub
-                ? this.dstController.SelectedDstMapResultToTransfer.Count()
+                ? this.dstController.SelectedDstMapResultToTransfer.Count
                 : this.dstController.SelectedHubMapResultToTransfer.Count;
 
             this.CanTransfer = this.NumberOfThing > 0;

--- a/DEHPMatlab/ViewModel/Row/MappingRowViewModel.cs
+++ b/DEHPMatlab/ViewModel/Row/MappingRowViewModel.cs
@@ -47,6 +47,30 @@ namespace DEHPMatlab.ViewModel.Row
         private MappingDirection direction;
 
         /// <summary>
+        /// Initializes a new <see cref="MappingRowViewModel"/> from a <see cref="ParameterToMatlabVariableMappingRowViewModel"/>
+        /// </summary>
+        /// <param name="currentMappingDirection">The current <see cref="MappingDirection"/></param>
+        /// <param name="mappedElement">The <see cref="ParameterToMatlabVariableMappingRowViewModel"/></param>
+        public MappingRowViewModel(MappingDirection currentMappingDirection, ParameterToMatlabVariableMappingRowViewModel mappedElement)
+        {
+            this.Direction = MappingDirection.FromHubToDst;
+
+            this.DstThing = new MappedThing()
+            {
+                Name = mappedElement.SelectedMatlabVariable.Name,
+                Value = mappedElement.SelectedMatlabVariable.Value
+            };
+
+            this.HubThing = new MappedThing()
+            {
+                Name = mappedElement.SelectedParameter.ModelCode(),
+                Value = mappedElement.SelectedValue.Representation
+            };
+
+            this.UpdateDirection(currentMappingDirection);
+        }
+
+        /// <summary>
         /// Initializes a new <see cref="MappingRowViewModel" /> from a mapped <see cref="ParameterOrOverrideBase" /> and
         /// <see cref="MatlabWorkspaceRowViewModel" />
         /// </summary>
@@ -132,6 +156,16 @@ namespace DEHPMatlab.ViewModel.Row
                 case MappingDirection.FromDstToHub when actualMappingDirection is MappingDirection.FromHubToDst:
                     this.HubThing.GridColumnIndex = 0;
                     this.DstThing.GridColumnIndex = 2;
+                    this.ArrowDirection = 180;
+                    break;
+                case MappingDirection.FromHubToDst when actualMappingDirection is MappingDirection.FromHubToDst:
+                    this.HubThing.GridColumnIndex = 0;
+                    this.DstThing.GridColumnIndex = 2;
+                    this.ArrowDirection = 0;
+                    break;
+                case MappingDirection.FromHubToDst when actualMappingDirection is MappingDirection.FromDstToHub:
+                    this.HubThing.GridColumnIndex = 2;
+                    this.DstThing.GridColumnIndex = 0;
                     this.ArrowDirection = 180;
                     break;
             }

--- a/DEHPMatlab/Views/Dialogs/HubMappingConfigurationDialog.xaml
+++ b/DEHPMatlab/Views/Dialogs/HubMappingConfigurationDialog.xaml
@@ -139,7 +139,7 @@
                                             </dxg:ColumnBase.EditTemplate>
                                         </dxg:TreeListColumn>
                                         <dxg:TreeListColumn Width="45" FieldName="OwnerShortName" Header="Owner" />
-                                        <dxg:TreeListColumn FieldName="Published" Header="Published SelectedValue" />
+                                        <dxg:TreeListColumn FieldName="Published" Header="Published Value" />
                                         <dxg:TreeListColumn FieldName="ScaleShortName" Header="Scale" />
                                         <dxg:TreeListColumn AllowEditing="True" FieldName="Switch">
                                             <dxg:ColumnBase.CellTemplate>
@@ -249,7 +249,7 @@
                                                     </Grid.RowDefinitions>
                                                     <TextBlock Height="Auto" Margin="3" FontSize="10" FontWeight="Normal" Text="Name: " />
                                                     <TextBlock Grid.Row="0" Grid.Column="1" Height="Auto" Margin="3" FontSize="10" Text="{Binding SelectedMatlabVariable.Name}" TextTrimming="CharacterEllipsis" />
-                                                    <TextBlock Grid.Column="0" Grid.Row="1"  Height="Auto" Margin="3" FontSize="10" FontWeight="Bold" Text="SelectedValue to replace: " />
+                                                    <TextBlock Grid.Column="0" Grid.Row="1"  Height="Auto" Margin="3" FontSize="10" FontWeight="Bold" Text="Value to replace: " />
                                                     <TextBlock Grid.Row="1" Grid.Column="1" Height="Auto" Margin="3" FontSize="10" Text="{Binding SelectedMatlabVariable.Value}" TextTrimming="CharacterEllipsis" />
                                                 </Grid>
                                                 <Button ToolTip="Delete this mapping row" Command="{Binding ElementName=Mapping, Path=DataContext.DeleteMappedRowCommand}" CommandParameter="{Binding SelectedParameter.Iid}" 

--- a/DEHPMatlab/Views/Dialogs/LogoutConfirmDialog.xaml
+++ b/DEHPMatlab/Views/Dialogs/LogoutConfirmDialog.xaml
@@ -1,0 +1,25 @@
+﻿<dx:DXDialogWindow x:Class="DEHPMatlab.Views.Dialogs.LogoutConfirmDialog"
+                   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                   xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                   mc:Ignorable="d"
+                   Title="Logout confirmation" Height="200" Width="250" ResizeMode="NoResize" WindowStartupLocation="CenterScreen" Topmost="True">
+    <Grid>
+        <Image Source="{dx:DXImage 'SvgImages/XAF/State_Validation_Warning.svg'}" VerticalAlignment="Top" Height="50"></Image>
+        <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center">
+            <Run Text="Warning!"/>
+            <LineBreak/>
+            <LineBreak/>
+            <Run Text="You have pending transfers."/>
+            <LineBreak></LineBreak>
+            <Run Text="By continuing, these transfers will be lost."/>
+        </TextBlock>
+    </Grid>
+
+    <dx:DXDialogWindow.FooterButtons>
+        <dx:DialogButton ToolTip="Proceed with logout and cancel pending transfers" Content="OK" MinWidth="65" DialogResult="OK"/>
+        <dx:DialogButton ToolTip="Cancel logout" IsDefault="True" Content="Cancel" IsCancel="True" MinWidth="65" DialogResult="Cancel"/>
+    </dx:DXDialogWindow.FooterButtons>
+</dx:DXDialogWindow>

--- a/DEHPMatlab/Views/Dialogs/LogoutConfirmDialog.xaml.cs
+++ b/DEHPMatlab/Views/Dialogs/LogoutConfirmDialog.xaml.cs
@@ -1,0 +1,43 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="LogoutConfirmDialog.xaml.cs" company="RHEA System S.A.">
+// Copyright (c) 2020-2022 RHEA System S.A.
+// 
+// Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate.
+// 
+// This file is part of DEHPMatlab
+// 
+// The DEHPMatlab is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+// 
+// The DEHPMatlab is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPMatlab.Views.Dialogs
+{
+    using System.Diagnostics.CodeAnalysis;
+
+    /// <summary>
+    /// Interaction logic for HubLogoutConfirmDialog.xaml
+    /// </summary>
+    public partial class LogoutConfirmDialog
+    {
+        /// <summary>
+        /// Initializes a new <see cref="LogoutConfirmDialog"/>
+        /// </summary>
+        [ExcludeFromCodeCoverage]
+        public LogoutConfirmDialog()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-MATLAB/pulls) open
- [x] I have verified that I am following the DEHP-MATLAB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-MATLAB/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #32 
- Transfer from hub to dst implemented
- If a Parameter is selected for mapping but not its ElementDefinition, the ElementDefinition is now added to the Mapping Configuration Dialog

<!-- Thanks for contributing to DEHP-MATLAB! -->