### PR TITLE
Matrices can be mapped into SFPT and APT : fixes #10

### DIFF
--- a/DEHPMatlab.Tests/MappingRules/MatlabVariableToElementDefinitionRuleTestFixture.cs
+++ b/DEHPMatlab.Tests/MappingRules/MatlabVariableToElementDefinitionRuleTestFixture.cs
@@ -414,8 +414,8 @@ namespace DEHPMatlab.Tests.MappingRules
             Assert.DoesNotThrow(() => this.rule.UpdateValueSet(variable, parameter));
             
             variable.UnwrapVariableRowViewModels();
-            variable.SampledFunctionParameters.First().IsDependantParameter = true;
-            variable.SampledFunctionParameters.Last().IsDependantParameter = false;
+            variable.SampledFunctionParameterParameterAssignementRows.First().IsDependantParameter = true;
+            variable.SampledFunctionParameterParameterAssignementRows.Last().IsDependantParameter = false;
             Assert.DoesNotThrow(() => this.rule.UpdateValueSet(variable, parameter));
             Assert.AreEqual("2", parameter.ValueSet.First().Computed.First());
         }

--- a/DEHPMatlab.Tests/MappingRules/MatlabVariableToElementDefinitionRuleTestFixture.cs
+++ b/DEHPMatlab.Tests/MappingRules/MatlabVariableToElementDefinitionRuleTestFixture.cs
@@ -357,5 +357,120 @@ namespace DEHPMatlab.Tests.MappingRules
             Assert.DoesNotThrow(() => this.rule.UpdateValueSet(variableRowViewModel, parameter2));
             Assert.Throws<NullReferenceException>(() => this.rule.UpdateValueSet(null, null));
         }
+
+        [Test]
+        public void VerifyUpdateValueSetSFPT()
+        {
+            var sfpt = new SampledFunctionParameterType()
+            {
+                Name = "TextXQuantity",
+                IndependentParameterType =
+                {
+                    new IndependentParameterTypeAssignment()
+                    {
+                        ParameterType = new SimpleQuantityKind()
+                        {
+                            Name = "IndependentText"
+                        }, 
+                        MeasurementScale = this.scale
+                    }
+                },
+
+                DependentParameterType =
+                {
+                    new DependentParameterTypeAssignment()
+                    {
+                        ParameterType = new SimpleQuantityKind()
+                        {
+                            Name = "DependentQuantityKing",
+                            DefaultScale = this.scale,
+                            PossibleScale = { this.scale }
+                        },
+                        MeasurementScale = this.scale
+                    }
+                }
+            };
+
+            var arrayValue = new object[2, 3];
+
+            for (var i = 0; i < arrayValue.GetLength(0); i++)
+            {
+                for (var j = 0; j < arrayValue.GetLength(1); j++)
+                {
+                    arrayValue.SetValue(i + j + 1, i, j);
+                }
+            }
+
+            var variable = new MatlabWorkspaceRowViewModel("a", arrayValue);
+
+            var parameter = new Parameter()
+            {
+                Iid = new Guid(),
+                ParameterType = sfpt, 
+                Container = new ElementDefinition(new Guid(), null, null), 
+                ValueSet = { new ParameterValueSet() }
+            };
+
+            Assert.DoesNotThrow(() => this.rule.UpdateValueSet(variable, parameter));
+            
+            variable.UnwrapVariableRowViewModels();
+            variable.SampledFunctionParameters.First().IsDependantParameter = true;
+            variable.SampledFunctionParameters.Last().IsDependantParameter = false;
+            Assert.DoesNotThrow(() => this.rule.UpdateValueSet(variable, parameter));
+            Assert.AreEqual("2", parameter.ValueSet.First().Computed.First());
+        }
+
+        [Test]
+        public void VerifyMappingArrayParameterType()
+        {
+            var arrayParameter = new ArrayParameterType()
+            {
+                Name = "Array3x2",
+                ShortName = "array3x2",
+            };
+
+            arrayParameter.Dimension = new OrderedItemList<int>(arrayParameter) { 3, 2 };
+
+            var simpleQuantityKind = new SimpleQuantityKind()
+            {
+                Name = "aSimpleQuantity",
+                PossibleScale = { this.scale },
+                DefaultScale = this.scale
+            };
+
+            for (var i = 0; i < 6; i++)
+            {
+                arrayParameter.Component.Add(new ParameterTypeComponent()
+                {
+                    ParameterType = simpleQuantityKind,
+                    Scale = this.scale
+                });
+            }
+
+            var parameter = new Parameter()
+            {
+                Iid = new Guid(),
+                ParameterType = arrayParameter,
+                Container = new ElementDefinition(new Guid(), null, null),
+                ValueSet = { new ParameterValueSet() }
+            };
+
+            var arrayValue = new object[3, 2];
+
+            for (var i = 0; i < arrayValue.GetLength(0); i++)
+            {
+                for (var j = 0; j < arrayValue.GetLength(1); j++)
+                {
+                    arrayValue.SetValue(i + j + 1, i, j);
+                }
+            }
+
+            var variable = new MatlabWorkspaceRowViewModel("a", arrayValue);
+
+            variable.UnwrapVariableRowViewModels();
+            Assert.DoesNotThrow(() => this.rule.UpdateValueSet(variable, parameter));
+            Assert.AreEqual("1", parameter.ValueSet.First().Computed.First());
+            Assert.AreEqual(6, parameter.ValueSet.First().Computed.Count());
+        }
     }
 }

--- a/DEHPMatlab.Tests/NetChange/HubNetChangePreviewViewModelTestFixture.cs
+++ b/DEHPMatlab.Tests/NetChange/HubNetChangePreviewViewModelTestFixture.cs
@@ -323,6 +323,7 @@ namespace DEHPMatlab.Tests.NetChange
             Assert.AreEqual(3, elements.Count);
             Assert.DoesNotThrow(() => this.viewModel.ComputeValues());
             Assert.AreEqual(3, elements.Count);
+            Assert.DoesNotThrow(() => this.viewModel.ComputeValuesWrapper());
 
             var parameterRowViewModels = elements.First(x => x.Thing.Iid == this.elementDefinition0.Iid)
                 .ContainedRows.OfType<ParameterRowViewModel>();
@@ -333,8 +334,6 @@ namespace DEHPMatlab.Tests.NetChange
                 .ContainedRows.OfType<ParameterRowViewModel>();
 
             Assert.AreEqual(1, lastElementParameters.Count());
-
-            CDPMessageBus.Current.ClearSubscriptions();
         }
 
         [Test]

--- a/DEHPMatlab.Tests/ViewModel/Dialogs/DstMappingConfigurationDialogViewModelTestFixture.cs
+++ b/DEHPMatlab.Tests/ViewModel/Dialogs/DstMappingConfigurationDialogViewModelTestFixture.cs
@@ -478,16 +478,16 @@ namespace DEHPMatlab.Tests.ViewModel.Dialogs
             }
 
             var variable = new MatlabWorkspaceRowViewModel("aName", array);
-            Assert.IsEmpty(variable.SampledFunctionParameters);
+            Assert.IsEmpty(variable.SampledFunctionParameterParameterAssignementRows);
 
             variable.UnwrapVariableRowViewModels();
-            Assert.AreEqual(2, variable.SampledFunctionParameters.Count);
+            Assert.AreEqual(2, variable.SampledFunctionParameterParameterAssignementRows.Count);
             Assert.AreEqual(RowColumnSelection.Column, variable.RowColumnSelection);
-            Assert.IsFalse(variable.SampledFunctionParameters.First().IsDependantParameter);
-            Assert.AreEqual(1, variable.SampledFunctionParameters.Last().Index);
+            Assert.IsFalse(variable.SampledFunctionParameterParameterAssignementRows.First().IsDependantParameter);
+            Assert.AreEqual(1, variable.SampledFunctionParameterParameterAssignementRows.Last().Index);
 
             variable.RowColumnSelection = RowColumnSelection.Row;
-            Assert.AreEqual(3, variable.SampledFunctionParameters.Count);
+            Assert.AreEqual(3, variable.SampledFunctionParameterParameterAssignementRows.Count);
 
             this.viewModel.Variables.Add(variable);
             this.viewModel.SelectedThing = variable;

--- a/DEHPMatlab.Tests/ViewModel/MappingViewModelTestFixture.cs
+++ b/DEHPMatlab.Tests/ViewModel/MappingViewModelTestFixture.cs
@@ -213,6 +213,83 @@ namespace DEHPMatlab.Tests.ViewModel
             this.dstMapResult.Clear();
 
             Assert.IsEmpty(this.viewModel.MappingRows);
+            
+            var scale = new RatioScale() { Name = "scale", NumberSet = NumberSetKind.REAL_NUMBER_SET };
+
+            var sfpt = new SampledFunctionParameterType()
+            {
+                Name = "TextXQuantity",
+                IndependentParameterType =
+                {
+                    new IndependentParameterTypeAssignment()
+                    {
+                        ParameterType = new SimpleQuantityKind()
+                        {
+                            Name = "IndependentText",
+                            DefaultScale = scale,
+                            PossibleScale = { scale },
+                        },
+                        MeasurementScale = scale
+                    }
+                },
+
+                DependentParameterType =
+                {
+                    new DependentParameterTypeAssignment()
+                    {
+                        ParameterType = new SimpleQuantityKind()
+                        {
+                            Name = "DependentQuantityKing",
+                            DefaultScale = scale,
+                            PossibleScale = { scale }
+                        },
+                        MeasurementScale = scale
+                    },
+                    new DependentParameterTypeAssignment()
+                    {
+                        ParameterType = new SimpleQuantityKind()
+                        {
+                            Name = "DependentQuantityKing2",
+                            DefaultScale = scale,
+                            PossibleScale = { scale }
+                        },
+                        MeasurementScale = scale
+                    }
+                }
+            };
+
+            var parameter = new Parameter()
+            {
+                Iid = Guid.NewGuid(),
+                ParameterType = sfpt,
+                ValueSet =
+                {
+                    new ParameterValueSet()
+                    {
+                        Computed = new ValueArray<string>(new []{"8", "5","3"}),
+                        Manual = new ValueArray<string>(new []{"5"}),
+                        Reference = new ValueArray<string>(new []{"3"})
+                    }
+                }
+            };
+
+            parameter.Container = this.element0;
+            this.element0.Parameter.Add(parameter);
+
+            toAdd = new ParameterToMatlabVariableMappingRowViewModel()
+            {
+                SelectedParameter = parameter,
+                SelectedMatlabVariable = new MatlabWorkspaceRowViewModel("a", new object[3,1]),
+                SelectedValue = new ValueSetValueRowViewModel(this.parameter0.QueryParameterBaseValueSet(null, null), "8", null)
+            };
+
+            this.dstController.Setup(x => x.ParameterVariable).Returns(new Dictionary<ParameterOrOverrideBase, MatlabWorkspaceRowViewModel>()
+            {
+                { parameter, toAdd.SelectedMatlabVariable}
+            });
+
+            this.hubMapResult.Add(toAdd);
+            this.dstMapResult.Add(this.element0);
         }
     }
 }

--- a/DEHPMatlab/DstController/DstController.cs
+++ b/DEHPMatlab/DstController/DstController.cs
@@ -457,7 +457,7 @@ namespace DEHPMatlab.DstController
                 this.SelectedDstMapResultToTransfer.Clear();
                 this.DstMapResult.Clear();
 
-                this.LoadMappingFromDstToHub();
+                this.LoadMapping();
 
                 CDPMessageBus.Current.SendMessage(new UpdateObjectBrowserTreeEvent(true));
             }
@@ -503,7 +503,7 @@ namespace DEHPMatlab.DstController
 
             this.mappingConfigurationService.RefreshExternalIdentifierMap();
 
-            this.LoadMappingFromHubToDst();
+            this.LoadMapping();
 
             CDPMessageBus.Current.SendMessage(new UpdateDstVariableTreeEvent(true));
         }
@@ -703,7 +703,7 @@ namespace DEHPMatlab.DstController
         /// <returns>The number of mapped things loaded</returns>
         private int LoadMappingFromDstToHub()
         {
-            if (this.mappingConfigurationService.LoadMappingFromDstToHub(this.MatlabWorkspaceInputRowViewModels) is not { } mappedVariables || !mappedVariables.Any())
+            if (this.mappingConfigurationService.LoadMappingFromDstToHub(this.MatlabAllWorkspaceRowViewModels) is not { } mappedVariables || !mappedVariables.Any())
             {
                 return 0;
             }

--- a/DEHPMatlab/Enumerator/RowColumnSelection.cs
+++ b/DEHPMatlab/Enumerator/RowColumnSelection.cs
@@ -30,12 +30,12 @@ namespace DEHPMatlab.Enumerator
     public enum RowColumnSelection
     {
         /// <summary>
-        /// Define that the independent and dependant parameter type are stored in two differents columns
+        /// Define that the independent and dependant parameter type are stored in differents columns
         /// </summary>
         Column,
 
         /// <summary>
-        /// Define that the independent and dependant parameter type are stored in two differents rows
+        /// Define that the independent and dependant parameter type are stored in differents rows
         /// </summary>
         Row
     }

--- a/DEHPMatlab/Enumerator/RowColumnSelection.cs
+++ b/DEHPMatlab/Enumerator/RowColumnSelection.cs
@@ -1,0 +1,42 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RowColumnSelection.cs" company="RHEA System S.A.">
+// Copyright (c) 2020-2022 RHEA System S.A.
+// 
+// Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate.
+// 
+// This file is part of DEHPMatlab
+// 
+// The DEHPMatlab is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+// 
+// The DEHPMatlab is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPMatlab.Enumerator
+{
+    /// <summary>
+    /// The <see cref="RowColumnSelection"/> represents if the independant and dependant parameter are stored into columns or rows
+    /// </summary>
+    public enum RowColumnSelection
+    {
+        /// <summary>
+        /// Define that the independent and dependant parameter type are stored in two differents columns
+        /// </summary>
+        Column,
+
+        /// <summary>
+        /// Define that the independent and dependant parameter type are stored in two differents rows
+        /// </summary>
+        Row
+    }
+}

--- a/DEHPMatlab/Extensions/ArrayParameterTypeExtensions.cs
+++ b/DEHPMatlab/Extensions/ArrayParameterTypeExtensions.cs
@@ -1,0 +1,76 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ArrayParameterTypeExtensions.cs" company="RHEA System S.A.">
+// Copyright (c) 2020-2022 RHEA System S.A.
+// 
+// Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate.
+// 
+// This file is part of DEHPMatlab
+// 
+// The DEHPMatlab is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+// 
+// The DEHPMatlab is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPMatlab.Extensions
+{
+    using System;
+    using System.Linq;
+
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Validation;
+
+    /// <summary>
+    /// Provides extension methods for <see cref="ArrayParameterType"/>
+    /// </summary>
+    public static class ArrayParameterTypeExtensions
+    {
+        /// <summary>
+        /// Verify that the <paramref name="parameterType"/> is compatible with this dst adapter
+        /// </summary>
+        /// <param name="parameterType">The <see cref="ArrayParameterType"/></param>
+        /// <param name="value">The <see cref="object"/> value</param>
+        /// <param name="scale">The <see cref="MeasurementScale"/></param>
+        /// <returns>A value indicating if the <paramref name="parameterType"/> is compliant</returns>
+        public static bool Validate(this ArrayParameterType parameterType, object value, MeasurementScale scale = null)
+        {
+            if (value is not Array arrayValue)
+            {
+                return false;
+            }
+
+            if (arrayValue.Rank != parameterType.Rank)
+            {
+                return false;
+            }
+
+            if (!parameterType.HasSingleComponentType)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < arrayValue.Rank; i++)
+            {
+                if (arrayValue.GetLength(i) != parameterType.Dimension[i])
+                {
+                    return false;
+                }
+            }
+
+            scale ??= parameterType.Component.First().Scale;
+
+            var validation = parameterType.Component.First().ParameterType.Validate(arrayValue.GetValue(0, 0), scale);
+            return validation.ResultKind == ValidationResultKind.Valid;
+        }
+    }
+}

--- a/DEHPMatlab/Extensions/SampledFunctionParameterTypeExtensions.cs
+++ b/DEHPMatlab/Extensions/SampledFunctionParameterTypeExtensions.cs
@@ -45,10 +45,10 @@ namespace DEHPMatlab.Extensions
         /// <param name="parameterType">The <see cref="SampledFunctionParameterType"/></param>
         /// <param name="value">The <see cref="object"/> value</param>
         /// <param name="rowColumnSelection">The <see cref="RowColumnSelection"/></param>
-        /// <param name="parametersDefinition">The collection of <see cref="SampledFunctionParametersDefinitionRowViewModel"/></param>
+        /// <param name="parametersDefinition">The collection of <see cref="SampledFunctionParameterParameterAssignementRowViewModel"/></param>
         /// <returns>A value indicating if the <paramref name="parameterType"/> is compliant</returns>
         public static bool Validate(this SampledFunctionParameterType parameterType, object value,
-            RowColumnSelection rowColumnSelection, List<SampledFunctionParametersDefinitionRowViewModel> parametersDefinition)
+            RowColumnSelection rowColumnSelection, List<SampledFunctionParameterParameterAssignementRowViewModel> parametersDefinition)
         {
             if (value is not Array arrayValue)
             {

--- a/DEHPMatlab/Extensions/SampledFunctionParameterTypeExtensions.cs
+++ b/DEHPMatlab/Extensions/SampledFunctionParameterTypeExtensions.cs
@@ -1,0 +1,95 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SampledFunctionParameterTypeExtensions.cs" company="RHEA System S.A.">
+// Copyright (c) 2020-2022 RHEA System S.A.
+// 
+// Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate.
+// 
+// This file is part of DEHPMatlab
+// 
+// The DEHPMatlab is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+// 
+// The DEHPMatlab is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPMatlab.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Validation;
+
+    using DEHPMatlab.Enumerator;
+    using DEHPMatlab.ViewModel.Row;
+
+    /// <summary>
+    /// Provides extension methods for <see cref="SampledFunctionParameterType"/>
+    /// </summary>
+    public static class SampledFunctionParameterTypeExtensions
+    {
+        /// <summary>
+        /// Verify that the <paramref name="parameterType"/> is compatible with this dst adapter
+        /// </summary>
+        /// <param name="parameterType">The <see cref="SampledFunctionParameterType"/></param>
+        /// <param name="value">The <see cref="object"/> value</param>
+        /// <param name="rowColumnSelection">The <see cref="RowColumnSelection"/></param>
+        /// <param name="parametersDefinition">The collection of <see cref="SampledFunctionParametersDefinitionRowViewModel"/></param>
+        /// <returns>A value indicating if the <paramref name="parameterType"/> is compliant</returns>
+        public static bool Validate(this SampledFunctionParameterType parameterType, object value,
+            RowColumnSelection rowColumnSelection, List<SampledFunctionParametersDefinitionRowViewModel> parametersDefinition)
+        {
+            if (value is not Array arrayValue)
+            {
+                return false;
+            }
+
+            var dependantParameretersDefined = parametersDefinition.Count(x => x.IsDependantParameter);
+
+            var independantParametersDefined = parametersDefinition.Count(x => !x.IsDependantParameter);
+
+            if (parameterType.IndependentParameterType.Count != independantParametersDefined || parameterType.DependentParameterType.Count != dependantParameretersDefined)
+            {
+                return false;
+            }
+
+            var dependantIndex = 0;
+            var independantIndex = 0;
+
+            foreach (var parameterDefinition in parametersDefinition)
+            {
+                var parameterToValidate = !parameterDefinition.IsDependantParameter 
+                    ? parameterType.IndependentParameterType[independantIndex].ParameterType
+                    :  parameterType.DependentParameterType[dependantIndex].ParameterType;
+
+                var scale = !parameterDefinition.IsDependantParameter
+                    ? parameterType.IndependentParameterType[independantIndex++].MeasurementScale
+                    : parameterType.DependentParameterType[dependantIndex++].MeasurementScale;
+
+                var objectToValidate = rowColumnSelection == RowColumnSelection.Column
+                    ? arrayValue.GetValue(0, parameterDefinition.Index)
+                    : arrayValue.GetValue(parameterDefinition.Index, 0);
+
+                var validate = parameterToValidate.Validate(objectToValidate, scale);
+
+                if (validate.ResultKind != ValidationResultKind.Valid)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/DEHPMatlab/MappingRules/MatlabVariableToElementDefinitionRule.cs
+++ b/DEHPMatlab/MappingRules/MatlabVariableToElementDefinitionRule.cs
@@ -220,7 +220,7 @@ namespace DEHPMatlab.MappingRules
             switch (parameter.ParameterType)
             {
                 case SampledFunctionParameterType sampledFunction when sampledFunction.Validate(matlabVariable.ArrayValue,
-                    matlabVariable.RowColumnSelection, matlabVariable.SampledFunctionParameters.ToList()):
+                    matlabVariable.RowColumnSelection, matlabVariable.SampledFunctionParameterParameterAssignementRows.ToList()):
                     this.AssignNewValues(matlabVariable, valueSet);
                     break;
                 case ArrayParameterType arrayParameter when arrayParameter.Validate(matlabVariable.ArrayValue, matlabVariable.SelectedScale):
@@ -250,23 +250,23 @@ namespace DEHPMatlab.MappingRules
 
             var values = new List<string>();
 
-            var iMax = matlabVariable.RowColumnSelection == RowColumnSelection.Column ? arrayValue.GetLength(0) : arrayValue.GetLength(1);
+            var lengthToProcess = matlabVariable.RowColumnSelection == RowColumnSelection.Column ? arrayValue.GetLength(0) : arrayValue.GetLength(1);
 
-            var independants = matlabVariable.SampledFunctionParameters
+            var independants = matlabVariable.SampledFunctionParameterParameterAssignementRows
                 .Where(x => !x.IsDependantParameter).ToList();
 
-            var dependants = matlabVariable.SampledFunctionParameters
+            var dependants = matlabVariable.SampledFunctionParameterParameterAssignementRows
                 .Where(x => x.IsDependantParameter).ToList();
 
             var indexOrder = independants.Select(independant => independant.Index).ToList();
 
             indexOrder.AddRange(dependants.Select(x => x.Index));
 
-            for (var i = 0; i < iMax; i++)
+            for (var lengthIndex = 0; lengthIndex < lengthToProcess; lengthIndex++)
             {
                 foreach (var index in indexOrder)
                 {
-                    var valueToAdd = matlabVariable.RowColumnSelection == RowColumnSelection.Column ? arrayValue.GetValue(i, index): arrayValue.GetValue(index, i);
+                    var valueToAdd = matlabVariable.RowColumnSelection == RowColumnSelection.Column ? arrayValue.GetValue(lengthIndex, index): arrayValue.GetValue(index, lengthIndex);
                     values.Add(FormattableString.Invariant($"{valueToAdd}"));
                 }
             }
@@ -291,11 +291,11 @@ namespace DEHPMatlab.MappingRules
 
             var values = new List<string>();
 
-            for (var i = 0; i < arrayValue.GetLength(0); i++)
+            for (var rowIndex = 0; rowIndex < arrayValue.GetLength(0); rowIndex++)
             {
-                for (var j = 0; j < arrayValue.GetLength(1); j++)
+                for (var columnIndex = 0; columnIndex < arrayValue.GetLength(1); columnIndex++)
                 {
-                    values.Add(FormattableString.Invariant($"{arrayValue.GetValue(i,j)}"));
+                    values.Add(FormattableString.Invariant($"{arrayValue.GetValue(rowIndex,columnIndex)}"));
                 }
             }
 

--- a/DEHPMatlab/MappingRules/MatlabVariableToElementDefinitionRule.cs
+++ b/DEHPMatlab/MappingRules/MatlabVariableToElementDefinitionRule.cs
@@ -42,6 +42,8 @@ namespace DEHPMatlab.MappingRules
     using DEHPCommon.MappingEngine;
     using DEHPCommon.MappingRules.Core;
 
+    using DEHPMatlab.Enumerator;
+    using DEHPMatlab.Extensions;
     using DEHPMatlab.Services.MappingConfiguration;
     using DEHPMatlab.ViewModel.Row;
 
@@ -214,10 +216,93 @@ namespace DEHPMatlab.MappingRules
         public void UpdateValueSet(MatlabWorkspaceRowViewModel matlabVariable, ParameterBase parameter)
         {
             var valueSet = (ParameterValueSetBase)parameter.QueryParameterBaseValueSet(matlabVariable.SelectedOption, matlabVariable.SelectedActualFiniteState);
-            valueSet.Computed = new ValueArray<string>(new[] { FormattableString.Invariant($"{matlabVariable.ActualValue}") });
+
+            switch (parameter.ParameterType)
+            {
+                case SampledFunctionParameterType sampledFunction when sampledFunction.Validate(matlabVariable.ArrayValue,
+                    matlabVariable.RowColumnSelection, matlabVariable.SampledFunctionParameters.ToList()):
+                    this.AssignNewValues(matlabVariable, valueSet);
+                    break;
+                case ArrayParameterType arrayParameter when arrayParameter.Validate(matlabVariable.ArrayValue, matlabVariable.SelectedScale):
+                    this.AssignNewValuesToArray(matlabVariable, valueSet);
+                    break;
+                default:
+                    valueSet.Computed = new ValueArray<string>(new[] { FormattableString.Invariant($"{matlabVariable.ActualValue}") });
+                    break;
+            }
+
             valueSet.ValueSwitch = ParameterSwitchKind.COMPUTED;
 
             this.AddParameterToExternalIdentifierMap(parameter, matlabVariable);
+        }
+
+        /// <summary>
+        /// Assigns the new values the <paramref name="valueSet"/> in case of <see cref="SampledFunctionParameterType"/>
+        /// </summary>
+        /// <param name="matlabVariable">The <see cref="MatlabWorkspaceRowViewModel"/></param>
+        /// <param name="valueSet">The <see cref="IValueSet"/> to update</param>
+        private void AssignNewValues(MatlabWorkspaceRowViewModel matlabVariable, ParameterValueSetBase valueSet)
+        {
+            if (matlabVariable.ArrayValue is not Array arrayValue)
+            {
+                return;
+            }
+
+            var values = new List<string>();
+
+            var iMax = matlabVariable.RowColumnSelection == RowColumnSelection.Column ? arrayValue.GetLength(0) : arrayValue.GetLength(1);
+
+            var independants = matlabVariable.SampledFunctionParameters
+                .Where(x => !x.IsDependantParameter).ToList();
+
+            var dependants = matlabVariable.SampledFunctionParameters
+                .Where(x => x.IsDependantParameter).ToList();
+
+            var indexOrder = independants.Select(independant => independant.Index).ToList();
+
+            indexOrder.AddRange(dependants.Select(x => x.Index));
+
+            for (var i = 0; i < iMax; i++)
+            {
+                foreach (var index in indexOrder)
+                {
+                    var valueToAdd = matlabVariable.RowColumnSelection == RowColumnSelection.Column ? arrayValue.GetValue(i, index): arrayValue.GetValue(index, i);
+                    values.Add(FormattableString.Invariant($"{valueToAdd}"));
+                }
+            }
+
+            if (values.Any())
+            {
+                valueSet.Computed = new ValueArray<string>(values);
+            }
+        }
+
+        /// <summary>
+        /// Assigns the new values the <paramref name="valueSet"/> in case of <see cref="ArrayParameterType"/>
+        /// </summary>
+        /// <param name="matlabVariable">The <see cref="MatlabWorkspaceRowViewModel"/></param>
+        /// <param name="valueSet">The <see cref="IValueSet"/> to update</param>
+        private void AssignNewValuesToArray(MatlabWorkspaceRowViewModel matlabVariable, ParameterValueSetBase valueSet)
+        {
+            if (matlabVariable.ArrayValue is not Array arrayValue)
+            {
+                return;
+            }
+
+            var values = new List<string>();
+
+            for (var i = 0; i < arrayValue.GetLength(0); i++)
+            {
+                for (var j = 0; j < arrayValue.GetLength(1); j++)
+                {
+                    values.Add(FormattableString.Invariant($"{arrayValue.GetValue(i,j)}"));
+                }
+            }
+
+            if (values.Any())
+            {
+                valueSet.Computed = new ValueArray<string>(values);
+            }
         }
 
         /// <summary>

--- a/DEHPMatlab/ViewModel/Dialogs/DstMappingConfigurationDialogViewModel.cs
+++ b/DEHPMatlab/ViewModel/Dialogs/DstMappingConfigurationDialogViewModel.cs
@@ -58,6 +58,11 @@ namespace DEHPMatlab.ViewModel.Dialogs
         private readonly INavigationService navigationService;
 
         /// <summary>
+        /// Collection of <see cref="IDisposable"/>
+        /// </summary>
+        private readonly List<IDisposable> disposablesObservables = new();
+
+        /// <summary>
         /// Backing field for <see cref="SelectedThing"/>
         /// </summary>
         private MatlabWorkspaceRowViewModel selectedThing;
@@ -66,11 +71,6 @@ namespace DEHPMatlab.ViewModel.Dialogs
         /// Backing field for <see cref="CanContinue"/>
         /// </summary>
         private bool canContinue;
-
-        /// <summary>
-        /// Collection of <see cref="IDisposable"/>
-        /// </summary>
-        private List<IDisposable> disposablesObservables = new();
 
         /// <summary>
         /// Initializes a new <see cref="DstMappingConfigurationDialogViewModel"/>

--- a/DEHPMatlab/ViewModel/Dialogs/DstMappingConfigurationDialogViewModel.cs
+++ b/DEHPMatlab/ViewModel/Dialogs/DstMappingConfigurationDialogViewModel.cs
@@ -248,7 +248,7 @@ namespace DEHPMatlab.ViewModel.Dialogs
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(_ => this.UpdateHubFields(this.UpdateAvailableParameterType)));
 
-            this.disposablesObservables.Add(this.SelectedThing.SampledFunctionParameters.ItemChanged
+            this.disposablesObservables.Add(this.SelectedThing.SampledFunctionParameterParameterAssignementRows.ItemChanged
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(_ => this.UpdateHubFields(this.UpdateAvailableParameterType)));
         }
@@ -461,7 +461,7 @@ namespace DEHPMatlab.ViewModel.Dialogs
             {
                 SampledFunctionParameterType when this.SelectedThing is null => true,
                 SampledFunctionParameterType sampledFunctionParameterType =>
-                    sampledFunctionParameterType.Validate(this.SelectedThing?.ArrayValue, this.SelectedThing.RowColumnSelection, this.SelectedThing.SampledFunctionParameters.ToList()),
+                    sampledFunctionParameterType.Validate(this.SelectedThing?.ArrayValue, this.SelectedThing.RowColumnSelection, this.SelectedThing.SampledFunctionParameterParameterAssignementRows.ToList()),
                 ArrayParameterType when this.SelectedThing is null => true,
                 ArrayParameterType arrayParameterType =>
                     arrayParameterType.Validate(this.SelectedThing?.ArrayValue, this.SelectedThing?.SelectedScale),

--- a/DEHPMatlab/ViewModel/Dialogs/DstMappingConfigurationDialogViewModel.cs
+++ b/DEHPMatlab/ViewModel/Dialogs/DstMappingConfigurationDialogViewModel.cs
@@ -25,6 +25,7 @@
 namespace DEHPMatlab.ViewModel.Dialogs
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Reactive.Linq;
 
@@ -38,6 +39,8 @@ namespace DEHPMatlab.ViewModel.Dialogs
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
 
     using DEHPMatlab.DstController;
+    using DEHPMatlab.Enumerator;
+    using DEHPMatlab.Extensions;
     using DEHPMatlab.ViewModel.Dialogs.Interfaces;
     using DEHPMatlab.ViewModel.Row;
     using DEHPMatlab.Views.Dialogs;
@@ -63,6 +66,11 @@ namespace DEHPMatlab.ViewModel.Dialogs
         /// Backing field for <see cref="CanContinue"/>
         /// </summary>
         private bool canContinue;
+
+        /// <summary>
+        /// Collection of <see cref="IDisposable"/>
+        /// </summary>
+        private List<IDisposable> disposablesObservables = new();
 
         /// <summary>
         /// Initializes a new <see cref="DstMappingConfigurationDialogViewModel"/>
@@ -129,6 +137,11 @@ namespace DEHPMatlab.ViewModel.Dialogs
         /// Gets the collection of the available <see cref="Option"/> from the connected Hub Model
         /// </summary>
         public ReactiveList<Option> AvailableOptions { get; } = new();
+
+        /// <summary>
+        /// Gets the collection of all <see cref="RowColumnSelection"/> values
+        /// </summary>
+        public List<RowColumnSelection> RowColumnValues { get; } = new() { RowColumnSelection.Column, RowColumnSelection.Row };
 
         /// <summary>
         /// Initializes this view model properties
@@ -202,6 +215,42 @@ namespace DEHPMatlab.ViewModel.Dialogs
                     this.UpdateAvailableActualFiniteStates();
                     this.CheckCanExecute();
                 }));
+
+            this.WhenAnyValue(x => x.SelectedThing)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ => this.UpdateHubFields(() =>
+                {
+                    this.RefreshSelectedThingObservables();
+                    this.UpdateAvailableParameters();
+                    this.UpdateAvailableParameterType();
+                    this.UpdateAvailableElementsUsages();
+                }));
+        }
+
+        /// <summary>
+        /// Initializes the <see cref="Observable"/> for the <see cref="SelectedThing"/>
+        /// </summary>
+        private void RefreshSelectedThingObservables()
+        {
+            if (this.SelectedThing is null)
+            {
+                return;
+            }
+
+            foreach (var disposable in this.disposablesObservables)
+            {
+                disposable.Dispose();
+            }
+
+            this.disposablesObservables.Clear();
+
+            this.disposablesObservables.Add(this.WhenAnyValue(x => x.SelectedThing.RowColumnSelection)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ => this.UpdateHubFields(this.UpdateAvailableParameterType)));
+
+            this.disposablesObservables.Add(this.SelectedThing.SampledFunctionParameters.ItemChanged
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ => this.UpdateHubFields(this.UpdateAvailableParameterType)));
         }
 
         /// <summary>
@@ -381,10 +430,44 @@ namespace DEHPMatlab.ViewModel.Dialogs
         {
             this.AvailableParameterTypes.Clear();
 
-            this.AvailableParameterTypes.AddRange(this.HubController.OpenIteration
-                .GetContainerOfType<EngineeringModel>().RequiredRdls
-                .SelectMany(x => x.ParameterType)
-                .OrderBy(x => x.Name));
+            var isAnArray = this.SelectedThing?.ArrayValue != null;
+
+            var parameterTypes = this.HubController.OpenIteration
+                .GetContainerOfType<EngineeringModel>()
+                .RequiredRdls
+                .SelectMany(x => x.ParameterType);
+            
+            if (isAnArray)
+            {
+                parameterTypes = parameterTypes.Where(x => x is SampledFunctionParameterType or ArrayParameterType);
+            }
+
+            var filteredParameterTypes = parameterTypes
+                .Where(this.FilterParameterType)
+                .OrderBy(x => x.Name);
+
+            this.AvailableParameterTypes.AddRange(filteredParameterTypes);
+        }
+
+        /// <summary>
+        /// Verify if the <paramref name="parameterType"/> is <see cref="ScalarParameterType"/>
+        /// or is <see cref="SampledFunctionParameterType"/> and at least compatible with this dst adapter
+        /// </summary>
+        /// <param name="parameterType">The <see cref="ParameterType"/></param>
+        /// <returns>An value indicating whether the <paramref name="parameterType"/> is valid</returns>
+        private bool FilterParameterType(ParameterType parameterType)
+        {
+            return !parameterType.IsDeprecated && parameterType switch
+            {
+                SampledFunctionParameterType when this.SelectedThing is null => true,
+                SampledFunctionParameterType sampledFunctionParameterType =>
+                    sampledFunctionParameterType.Validate(this.SelectedThing?.ArrayValue, this.SelectedThing.RowColumnSelection, this.SelectedThing.SampledFunctionParameters.ToList()),
+                ArrayParameterType when this.SelectedThing is null => true,
+                ArrayParameterType arrayParameterType =>
+                    arrayParameterType.Validate(this.SelectedThing?.ArrayValue, this.SelectedThing?.SelectedScale),
+                ScalarParameterType => true,
+                _ => false
+            };
         }
 
         /// <summary>

--- a/DEHPMatlab/ViewModel/NetChangePreview/HubNetChangePreviewViewModel.cs
+++ b/DEHPMatlab/ViewModel/NetChangePreview/HubNetChangePreviewViewModel.cs
@@ -451,7 +451,7 @@ namespace DEHPMatlab.ViewModel.NetChangePreview
         /// <summary>
         /// Calls the <see cref="ComputeValues" /> with some household
         /// </summary>
-        private void ComputeValuesWrapper()
+        public void ComputeValuesWrapper()
         {
             this.IsBusy = true;
             var isExpanded = this.Things.First().IsExpanded;
@@ -621,7 +621,7 @@ namespace DEHPMatlab.ViewModel.NetChangePreview
 
                 var elementRow = this.VerifyElementIsInTheTree(elementBase.Value.First());
 
-                if (elementClone is ElementDefinition elementDefition)
+                if (elementClone is ElementDefinition { Container: { } } elementDefition)
                 {
                     elementRow.UpdateThing(elementDefition);
                     elementRow.UpdateChildren();

--- a/DEHPMatlab/ViewModel/Row/MatlabWorkspaceRowViewModel.cs
+++ b/DEHPMatlab/ViewModel/Row/MatlabWorkspaceRowViewModel.cs
@@ -306,9 +306,9 @@ namespace DEHPMatlab.ViewModel.Row
         public ReactiveList<IdCorrespondence> MappingConfigurations { get; set; } = new();
 
         /// <summary>
-        /// Gets the collection of <see cref="SampledFunctionParametersDefinitionRowViewModel"/>
+        /// Gets the collection of <see cref="SampledFunctionParameterParameterAssignementRowViewModel"/>
         /// </summary>
-        public ReactiveList<SampledFunctionParametersDefinitionRowViewModel> SampledFunctionParameters { get; } = new() { ChangeTrackingEnabled = true };
+        public ReactiveList<SampledFunctionParameterParameterAssignementRowViewModel> SampledFunctionParameterParameterAssignementRows { get; } = new() { ChangeTrackingEnabled = true };
 
         /// <summary>
         /// Verify if the <see cref="SelectedParameterType" /> is compatible with the current variable
@@ -319,7 +319,7 @@ namespace DEHPMatlab.ViewModel.Row
             return this.SelectedParameterType switch
             {
                 SampledFunctionParameterType sampledFunctionParameterType => 
-                    sampledFunctionParameterType.Validate(this.ArrayValue, this.RowColumnSelection, this.SampledFunctionParameters.ToList()),
+                    sampledFunctionParameterType.Validate(this.ArrayValue, this.RowColumnSelection, this.SampledFunctionParameterParameterAssignementRows.ToList()),
                 ArrayParameterType arrayParameterType => 
                     arrayParameterType.Validate(this.ArrayValue, this.SelectedScale),
                 ScalarParameterType scalarParameterType =>
@@ -391,11 +391,11 @@ namespace DEHPMatlab.ViewModel.Row
         }
 
         /// <summary>
-        /// Populate the <see cref="SampledFunctionParameters"/> collections
+        /// Populate the <see cref="SampledFunctionParameterParameterAssignementRows"/> collections
         /// </summary>
         private void PopulateSampledFunctionParameters()
         {
-            this.SampledFunctionParameters.Clear();
+            this.SampledFunctionParameterParameterAssignementRows.Clear();
 
             if (this.ArrayValue is not Array arrayValueAsArray)
             {
@@ -404,9 +404,9 @@ namespace DEHPMatlab.ViewModel.Row
 
             var parametersCount = this.RowColumnSelection == RowColumnSelection.Column ? arrayValueAsArray.GetLength(1) : arrayValueAsArray.GetLength(0);
 
-            for (var i = 0; i < parametersCount; i++)
+            for (var parameterIndex = 0; parameterIndex < parametersCount; parameterIndex++)
             {
-                this.SampledFunctionParameters.Add(new SampledFunctionParametersDefinitionRowViewModel(i, i != 0));
+                this.SampledFunctionParameterParameterAssignementRows.Add(new SampledFunctionParameterParameterAssignementRowViewModel(parameterIndex, parameterIndex != 0));
             }
         }
     }

--- a/DEHPMatlab/ViewModel/Row/SampledFunctionParameterParameterAssignementRowViewModel.cs
+++ b/DEHPMatlab/ViewModel/Row/SampledFunctionParameterParameterAssignementRowViewModel.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="SampledFunctionParametersDefinitionRowViewModel.cs" company="RHEA System S.A.">
+// <copyright file="SampledFunctionParameterParameterAssignementRowViewModel.cs" company="RHEA System S.A.">
 // Copyright (c) 2020-2022 RHEA System S.A.
 // 
 // Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate.
@@ -31,7 +31,7 @@ namespace DEHPMatlab.ViewModel.Row
     /// <summary>
     /// Used to define the mapping for array to <see cref="SampledFunctionParameterType"/> parameters
     /// </summary>
-    public class SampledFunctionParametersDefinitionRowViewModel : ReactiveObject
+    public class SampledFunctionParameterParameterAssignementRowViewModel : ReactiveObject
     {
         /// <summary>
         /// Backing field for <see cref="Index"/>
@@ -44,11 +44,11 @@ namespace DEHPMatlab.ViewModel.Row
         private bool isDependantParameter;
 
         /// <summary>
-        /// Initializes a new <see cref="SampledFunctionParametersDefinitionRowViewModel"/>
+        /// Initializes a new <see cref="SampledFunctionParameterParameterAssignementRowViewModel"/>
         /// </summary>
         /// <param name="index">The index</param>
         /// <param name="isDependantParameter">The assert</param>
-        public SampledFunctionParametersDefinitionRowViewModel(int index, bool isDependantParameter)
+        public SampledFunctionParameterParameterAssignementRowViewModel(int index, bool isDependantParameter)
         {
             this.Index = index;
             this.IsDependantParameter = isDependantParameter;

--- a/DEHPMatlab/ViewModel/Row/SampledFunctionParametersDefinitionRowViewModel.cs
+++ b/DEHPMatlab/ViewModel/Row/SampledFunctionParametersDefinitionRowViewModel.cs
@@ -1,0 +1,75 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SampledFunctionParametersDefinitionRowViewModel.cs" company="RHEA System S.A.">
+// Copyright (c) 2020-2022 RHEA System S.A.
+// 
+// Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate.
+// 
+// This file is part of DEHPMatlab
+// 
+// The DEHPMatlab is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+// 
+// The DEHPMatlab is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPMatlab.ViewModel.Row
+{
+    using CDP4Common.SiteDirectoryData;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Used to define the mapping for array to <see cref="SampledFunctionParameterType"/> parameters
+    /// </summary>
+    public class SampledFunctionParametersDefinitionRowViewModel : ReactiveObject
+    {
+        /// <summary>
+        /// Backing field for <see cref="Index"/>
+        /// </summary>
+        private int index;
+
+        /// <summary>
+        /// Backing field for <see cref="IsDependantParameter"/>
+        /// </summary>
+        private bool isDependantParameter;
+
+        /// <summary>
+        /// Initializes a new <see cref="SampledFunctionParametersDefinitionRowViewModel"/>
+        /// </summary>
+        /// <param name="index">The index</param>
+        /// <param name="isDependantParameter">The assert</param>
+        public SampledFunctionParametersDefinitionRowViewModel(int index, bool isDependantParameter)
+        {
+            this.Index = index;
+            this.IsDependantParameter = isDependantParameter;
+        }
+
+        /// <summary>
+        /// The index of the current Row or Column to define
+        /// </summary>
+        public int Index
+        {
+            get => this.index;
+            set => this.RaiseAndSetIfChanged(ref this.index, value);
+        }
+
+        /// <summary>
+        /// Asserts if the corrent Row or Column represents a DependantParameter or not
+        /// </summary>
+        public bool IsDependantParameter
+        {
+            get => this.isDependantParameter;
+            set => this.RaiseAndSetIfChanged(ref this.isDependantParameter, value);
+        }
+    }
+}

--- a/DEHPMatlab/Views/Dialogs/DstMappingConfigurationDialog.xaml
+++ b/DEHPMatlab/Views/Dialogs/DstMappingConfigurationDialog.xaml
@@ -81,24 +81,58 @@
                 </dxg:TreeListControl>
             </GroupBox>
             <GroupBox Grid.Row="1" Header="Select Value Set" Margin="10" Padding="10">
-                <Grid Margin="5">
+                <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="4*" />
-                        <ColumnDefinition Width="6*" />
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
-                    <Label Grid.Row="1" Grid.Column="0" Content="Element Definition:" />
+                    <Grid Grid.Column="0" Margin="5">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Label Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Height="25" HorizontalAlignment="Left" Content="Parameters are split into :" />
+                            <dxe:ComboBoxEdit Grid.Row="0" Grid.Column="1" Margin="5" Height="25"
+                                              ItemsSource="{Binding RowColumnValues}"
+                                              SelectedItem="{Binding SelectedThing.RowColumnSelection}"
+                                              Width="Auto" ToolTip="Select Row if the array is a [2xX] array, Column if the array is a [Xx2] array."/>
+                            <dxg:GridControl Grid.Row="1" Grid.ColumnSpan="2" Grid.Column="0" Margin="5"
+                                             Height="190" ItemsSource="{Binding SelectedThing.SampledFunctionParameters}" 
+                                             ToolTip="Assign each row or column to the correct type of dependant or independant parameter type">
+                                <dxg:GridControl.View>
+                                    <dxg:TableView VerticalScrollbarVisibility="Auto"/>
+                                </dxg:GridControl.View>
+                                <dxg:GridControl.Columns>
+                                    <dxg:GridColumn AllowEditing="False" FieldName="Index" UnboundType="Integer"/>
+                                    <dxg:GridColumn AllowEditing="True"  FieldName="IsDependantParameter" UnboundType="Boolean"/>
+                                </dxg:GridControl.Columns>
+                            </dxg:GridControl>
+                        </Grid>
+                    </Grid>
+                    <Grid Grid.Column="1" Margin="5">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="4*" />
+                            <ColumnDefinition Width="6*" />
+                        </Grid.ColumnDefinitions>
+
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <Label Grid.Row="1" Grid.Column="0" Content="Element Definition:" />
                         <dxe:ComboBoxEdit Grid.Row="1" Grid.Column="1" Margin="2" AllowNullInput="True" AutoComplete="True" ClearSelectionOnBackspace="True" 
                                               DisplayMember="ShortName" ItemsSource="{Binding AvailableElementDefinitions}"
                                               NullText="Create New Element Definition" NullValueButtonPlacement="EditBox"
@@ -171,7 +205,6 @@
                                           SelectedItem="{Binding SelectedThing.SelectedScale}"
                                           ToolTip="Select a scale if the parameter type allows to do so"
                                           ShowNullTextForEmptyValue="True" ValidateOnTextInput="False" ValueMember="Name" />
-
                         </Grid>
                         <Label Grid.Row="5" Grid.Column="0" Content="Parameter:" />
                         <dxe:ComboBoxEdit Grid.Row="5" Grid.Column="1" Margin="2" AllowNullInput="True" ApplyItemTemplateToSelectedItem="True" AutoComplete="True" ClearSelectionOnBackspace="True"
@@ -189,13 +222,15 @@
                                                       ToolTip="Select an ActualFiniteState when the selected Parameter has state dependency"
                                                       ShowNullTextForEmptyValue="True" ValidateOnTextInput="False" ValueMember="Name" />
                         <Label Grid.Row="7" Grid.Column="0" Content="Option:" />
-                    <dxe:ComboBoxEdit Grid.Row="7" Grid.Column="1" Margin="2" AutoComplete="True" DisplayMember="ShortName"
+                        <dxe:ComboBoxEdit Grid.Row="7" Grid.Column="1" Margin="2" AutoComplete="True" DisplayMember="ShortName"
                                               ItemsSource="{Binding AvailableOptions}" SelectedIndex="0" NullText="Select an option"
                                               SelectedItem="{Binding SelectedThing.SelectedOption}" NullValueButtonPlacement="EditBox"
                                               ShowNullTextForEmptyValue="True" ValidateOnTextInput="False" 
                                               ValueMember="Name" AllowNullInput="True" 
                                               ToolTip="Select an Option when mapping to an option dependant Parameter"/>
+                    </Grid>
                 </Grid>
+                
             </GroupBox>
             <Grid Grid.Row="2">
                 <Grid.ColumnDefinitions>

--- a/DEHPMatlab/Views/Dialogs/DstMappingConfigurationDialog.xaml
+++ b/DEHPMatlab/Views/Dialogs/DstMappingConfigurationDialog.xaml
@@ -103,7 +103,7 @@
                                               SelectedItem="{Binding SelectedThing.RowColumnSelection}"
                                               Width="Auto" ToolTip="Select Row if the array is a [2xX] array, Column if the array is a [Xx2] array."/>
                             <dxg:GridControl Grid.Row="1" Grid.ColumnSpan="2" Grid.Column="0" Margin="5"
-                                             Height="190" ItemsSource="{Binding SelectedThing.SampledFunctionParameters}" 
+                                             Height="190" ItemsSource="{Binding SelectedThing.SampledFunctionParameterParameterAssignementRows}" 
                                              ToolTip="Assign each row or column to the correct type of dependant or independant parameter type">
                                 <dxg:GridControl.View>
                                     <dxg:TableView VerticalScrollbarVisibility="Auto"/>

--- a/DEHPMatlab/Views/Dialogs/HubMappingConfigurationDialog.xaml
+++ b/DEHPMatlab/Views/Dialogs/HubMappingConfigurationDialog.xaml
@@ -12,7 +12,7 @@
                    xmlns:engineeringModelData="clr-namespace:CDP4Common.EngineeringModelData;assembly=CDP4Common"
                    xmlns:viewModels="clr-namespace:DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows;assembly=DEHPCommon"
                    xmlns:converters="clr-namespace:DEHPCommon.Converters;assembly=DEHPCommon"
-                   Title="HubMappingConfigurationDialog"
+                   Title="Mapping Configuration Dialog"
                    WindowStartupLocation="CenterScreen" Topmost="True"
                    mc:Ignorable="d" MinHeight="450" MinWidth="800">
     <Window.Resources>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-MATLAB/pulls) open
- [x] I have verified that I am following the DEHP-MATLAB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-MATLAB/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #10 
- Matrices can be mapped to Parameter with valid SampledFunctionParameterType or valid ArrayParameterType
- Mapped element composed by matrices can be transfer from Dst to Hub

<!-- Thanks for contributing to DEHP-MATLAB! -->