### PR TITLE
Only selected parameters are transferred ; fixes 40

### DIFF
--- a/DEHPMatlab.Tests/DstController/DstControllerTestFixture.cs
+++ b/DEHPMatlab.Tests/DstController/DstControllerTestFixture.cs
@@ -308,7 +308,7 @@ namespace DEHPMatlab.Tests.DstController
                 }
             };
 
-            this.dstController.SelectedDstMapResultToTransfer.Add(elementDefinition);
+            this.dstController.SelectedDstMapResultToTransfer.Add(parameter);
 
             var parameterOverride = new ParameterOverride(Guid.NewGuid(), null, null)
             {
@@ -320,21 +320,16 @@ namespace DEHPMatlab.Tests.DstController
                         Computed = new ValueArray<string>(new[] { "654321" }),
                         ValueSwitch = ParameterSwitchKind.COMPUTED
                     }
-                }
+                },
+                Container = new ElementUsage()
             };
 
-            this.dstController.SelectedDstMapResultToTransfer.Add(new ElementUsage
-            {
-                ElementDefinition = elementDefinition,
-                ParameterOverride =
-                {
-                    parameterOverride
-                }
-            });
+            this.dstController.SelectedDstMapResultToTransfer.Add(parameterOverride);
 
             var param = new Parameter()
             {
-                ParameterType = new BooleanParameterType()
+                ParameterType = new BooleanParameterType(),
+                Container = new ElementDefinition()
             };
 
             var variable = new MatlabWorkspaceRowViewModel("a", 0)

--- a/DEHPMatlab.Tests/NetChange/HubNetChangePreviewViewModelTestFixture.cs
+++ b/DEHPMatlab.Tests/NetChange/HubNetChangePreviewViewModelTestFixture.cs
@@ -36,8 +36,10 @@ namespace DEHPMatlab.Tests.NetChange
     using CDP4Common.Types;
 
     using CDP4Dal;
+    using CDP4Dal.Events;
     using CDP4Dal.Permission;
 
+    using DEHPCommon.Events;
     using DEHPCommon.HubController.Interfaces;
     using DEHPCommon.Services.ObjectBrowserTreeSelectorService;
     using DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows;
@@ -205,7 +207,7 @@ namespace DEHPMatlab.Tests.NetChange
 
             this.dstController = new Mock<IDstController>();
 
-            this.dstController.Setup(x => x.SelectedDstMapResultToTransfer).Returns(new ReactiveList<ElementBase>());
+            this.dstController.Setup(x => x.SelectedDstMapResultToTransfer).Returns(new ReactiveList<ParameterOrOverrideBase>());
 
             this.dstMapResult = new ReactiveList<ElementBase>()
             {
@@ -414,6 +416,15 @@ namespace DEHPMatlab.Tests.NetChange
 
             var parameterOverrideRow = elementUsageRow.ContainedRows.OfType<ParameterOverrideRowViewModel>().First();
             Assert.DoesNotThrow(() => this.viewModel.WhenItemSelectedChanges(parameterOverrideRow));
+
+            this.dstMapResult.Clear();
+        }
+
+        [Test]
+        public void VerifyCDPMessageBusListening()
+        {
+            Assert.DoesNotThrow(() => CDPMessageBus.Current.SendMessage(new UpdateObjectBrowserTreeEvent(true)));
+            Assert.DoesNotThrow(() => CDPMessageBus.Current.SendMessage(new UpdateObjectBrowserTreeEvent(false)));
         }
     }
 }

--- a/DEHPMatlab.Tests/ViewModel/Dialogs/DstMappingConfigurationDialogViewModelTestFixture.cs
+++ b/DEHPMatlab.Tests/ViewModel/Dialogs/DstMappingConfigurationDialogViewModelTestFixture.cs
@@ -229,10 +229,16 @@ namespace DEHPMatlab.Tests.ViewModel.Dialogs
         {
             Assert.IsFalse(this.viewModel.CanContinue);
 
-            this.viewModel.Variables.Add(new MatlabWorkspaceRowViewModel("aValidVariable", 5.5d)
+            var variable = new MatlabWorkspaceRowViewModel("aValidVariable", 5.5d)
             {
-                SelectedParameterType = this.quantityKindParameterType
-            });
+                SelectedParameterType = this.quantityKindParameterType,
+            };
+
+            Assert.IsFalse(variable.IsValid());
+            variable.SelectedScale = this.scale;
+            Assert.IsTrue(variable.IsValid());
+
+            this.viewModel.Variables.Add(variable);
 
             Assert.IsTrue(this.viewModel.CanContinue);
             Assert.AreEqual(2, this.viewModel.Variables.Count);

--- a/DEHPMatlab.Tests/ViewModel/DifferenceViewModelTestFixture.cs
+++ b/DEHPMatlab.Tests/ViewModel/DifferenceViewModelTestFixture.cs
@@ -27,6 +27,7 @@ namespace DEHPMatlab.Tests.ViewModel
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reactive.Concurrency;
 
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
@@ -83,6 +84,8 @@ namespace DEHPMatlab.Tests.ViewModel
         [SetUp]
         public void SetUp()
         {
+            RxApp.MainThreadScheduler = Scheduler.CurrentThread;
+            
             this.hubController = new Mock<IHubController>();
             this.dstController = new Mock<IDstController>();
             this.inputVariables = new ReactiveList<MatlabWorkspaceRowViewModel>();
@@ -486,7 +489,7 @@ namespace DEHPMatlab.Tests.ViewModel
             Assert.DoesNotThrow(() => this.viewModel.MatricesDifferenceCommand.Execute(null));
            
             this.navigationService.Verify(x => 
-                x.ShowDxDialog<MatricesDifferenceDialog, MatricesDifferenceDialogViewModel>(It.IsAny<MatricesDifferenceDialogViewModel>()), Times.Once);
+                x.ShowDxDialog<MatricesDifferenceDialog, MatricesDifferenceDialogViewModel>(It.IsAny<MatricesDifferenceDialogViewModel>()), Times.Exactly(2));
         }
 
         [Test]

--- a/DEHPMatlab.Tests/ViewModel/DifferenceViewModelTestFixture.cs
+++ b/DEHPMatlab.Tests/ViewModel/DifferenceViewModelTestFixture.cs
@@ -477,6 +477,13 @@ namespace DEHPMatlab.Tests.ViewModel
 
             Assert.IsTrue(this.viewModel.CanExecute);
             Assert.DoesNotThrow(() => this.viewModel.MatricesDifferenceCommand.Execute(null));
+
+            this.inputVariables.First().ArrayValue = variable.ArrayValue;
+            Assert.DoesNotThrow(() => CDPMessageBus.Current.SendMessage(new DifferenceEvent<MatlabWorkspaceRowViewModel>(true, variable)));
+            this.viewModel.SelectedThing = this.viewModel.Parameters.First();
+
+            Assert.IsTrue(this.viewModel.CanExecute);
+            Assert.DoesNotThrow(() => this.viewModel.MatricesDifferenceCommand.Execute(null));
            
             this.navigationService.Verify(x => 
                 x.ShowDxDialog<MatricesDifferenceDialog, MatricesDifferenceDialogViewModel>(It.IsAny<MatricesDifferenceDialogViewModel>()), Times.Once);

--- a/DEHPMatlab.Tests/ViewModel/MatlabTransferControlViewModelTestFixture.cs
+++ b/DEHPMatlab.Tests/ViewModel/MatlabTransferControlViewModelTestFixture.cs
@@ -51,7 +51,7 @@ namespace DEHPMatlab.Tests.ViewModel
         private Mock<IDstController> dstController;
         private Mock<IStatusBarControlViewModel> statusBar;
         private Mock<IExchangeHistoryService> exchangeHistory;
-        private ReactiveList<ElementBase> selectedDstMapResult;
+        private ReactiveList<ParameterOrOverrideBase> selectedDstMapResult;
         private ReactiveList<ParameterToMatlabVariableMappingRowViewModel> selectedHubMapResult;
 
         [SetUp]
@@ -63,7 +63,7 @@ namespace DEHPMatlab.Tests.ViewModel
             this.statusBar = new Mock<IStatusBarControlViewModel>();
             this.exchangeHistory = new Mock<IExchangeHistoryService>();
 
-            this.selectedDstMapResult = new ReactiveList<ElementBase>();
+            this.selectedDstMapResult = new ReactiveList<ParameterOrOverrideBase>();
             this.selectedHubMapResult = new ReactiveList<ParameterToMatlabVariableMappingRowViewModel>();
 
             this.dstController.Setup(x => x.SelectedDstMapResultToTransfer).Returns(this.selectedDstMapResult);
@@ -108,17 +108,18 @@ namespace DEHPMatlab.Tests.ViewModel
         [Test]
         public void VerifyTransferCommand()
         {
-            this.selectedDstMapResult.AddRange(new List<ElementBase>()
+            var elementDefinition = new ElementDefinition
             {
-                new ElementDefinition
-                {
-                    Parameter = { new Parameter() }
-                },
-                new ElementUsage
-                {
-                    ParameterOverride = { new ParameterOverride() }
-                }
-            });
+                Parameter = { new Parameter() }
+            };
+
+            var elementUsage = new ElementUsage
+            {
+                ParameterOverride = { new ParameterOverride() }
+            };
+             
+            this.selectedDstMapResult.AddRange(elementDefinition.Parameter);
+            this.selectedDstMapResult.AddRange(elementUsage.ParameterOverride);
             
             this.selectedHubMapResult.Add(new ParameterToMatlabVariableMappingRowViewModel());
 

--- a/DEHPMatlab/DstController/IDstController.cs
+++ b/DEHPMatlab/DstController/IDstController.cs
@@ -93,9 +93,9 @@ namespace DEHPMatlab.DstController
         Dictionary<ParameterOrOverrideBase, MatlabWorkspaceRowViewModel> ParameterVariable { get; }
 
         /// <summary>
-        /// Gets the collection of <see cref="ElementBase"/> that are selected to be transfered
+        /// Gets the collection of <see cref="ParameterOrOverrideBase"/> that are selected to be transfered
         /// </summary>
-        ReactiveList<ElementBase> SelectedDstMapResultToTransfer { get; }
+        ReactiveList<ParameterOrOverrideBase> SelectedDstMapResultToTransfer { get; }
 
         /// <summary>
         /// Gets the collection of <see cref="ParameterToMatlabVariableMappingRowViewModel"/> that are selected to be transfered

--- a/DEHPMatlab/ViewModel/MatlabTransferControlViewModel.cs
+++ b/DEHPMatlab/ViewModel/MatlabTransferControlViewModel.cs
@@ -133,6 +133,8 @@ namespace DEHPMatlab.ViewModel
         {
             this.dstController.DstMapResult.Clear();
             this.dstController.HubMapResult.Clear();
+            this.dstController.SelectedDstMapResultToTransfer.Clear();
+            this.dstController.SelectedHubMapResultToTransfer.Clear();
             this.dstController.ParameterVariable.Clear();
             this.exchangeHistoryService.ClearPending();
             await Task.Delay(1);

--- a/DEHPMatlab/ViewModel/NetChangePreview/HubNetChangePreviewViewModel.cs
+++ b/DEHPMatlab/ViewModel/NetChangePreview/HubNetChangePreviewViewModel.cs
@@ -243,7 +243,7 @@ namespace DEHPMatlab.ViewModel.NetChangePreview
 
                     foreach (var parameterRow in definitionViewModel.ContainedRows.OfType<ParameterRowViewModel>())
                     {
-                        parameterRow.IsSelectedForTransfer = areSelected;
+                        parameterRow.IsSelectedForTransfer = areSelected && this.IsThingTransferable(parameterRow);
                     }
 
                     this.AddOrRemoveToSelectedThingsToTransfer(definitionViewModel);
@@ -260,9 +260,9 @@ namespace DEHPMatlab.ViewModel.NetChangePreview
 
                     usageViewModel.IsSelectedForTransfer = areSelected;
 
-                    foreach (var parameterRow in usageViewModel.ContainedRows.OfType<ParameterRowViewModel>())
+                    foreach (var parameterRow in usageViewModel.ContainedRows.OfType<ParameterOverrideRowViewModel>())
                     {
-                        parameterRow.IsSelectedForTransfer = areSelected;
+                        parameterRow.IsSelectedForTransfer = areSelected && this.IsThingTransferable(parameterRow);
                     }
 
                     this.AddOrRemoveToSelectedThingsToTransfer(usageViewModel);
@@ -326,14 +326,6 @@ namespace DEHPMatlab.ViewModel.NetChangePreview
                     this.AddOrRemoveToSelectedThingsToTransfer(elementViewModel, elementUsage.ParameterOverride, parameterOverridesToAdd);
                     break;
             }
-
-            this.dstController.SelectedDstMapResultToTransfer.Remove(
-                this.dstController.SelectedDstMapResultToTransfer.FirstOrDefault(x => x.Iid == mappedElement.Iid && x.ShortName == mappedElement.ShortName));
-
-            if (elementViewModel.IsSelectedForTransfer)
-            {
-                this.dstController.SelectedDstMapResultToTransfer.Add(mappedElement);
-            }
         }
 
         /// <summary>
@@ -353,6 +345,11 @@ namespace DEHPMatlab.ViewModel.NetChangePreview
                 .Where(x => x is { })
                 .ToList();
 
+            foreach (var parameter in parameters)
+            {
+                this.dstController.SelectedDstMapResultToTransfer.Remove(parameter);
+            }
+
             parametersToAdd.RemoveAll(p => selectedParameters.FirstOrDefault(x => x.ParameterType.Iid == p.ParameterType.Iid) is { });
 
             parametersToAdd.AddRange(selectedParameters);
@@ -360,6 +357,8 @@ namespace DEHPMatlab.ViewModel.NetChangePreview
             parameters.Clear();
 
             parameters.AddRange(parametersToAdd);
+
+            this.dstController.SelectedDstMapResultToTransfer.AddRange(selectedParameters.Where(x => !this.dstController.SelectedDstMapResultToTransfer.Contains(x)));
         }
 
         /// <summary>

--- a/DEHPMatlab/ViewModel/Row/MatlabWorkspaceRowViewModel.cs
+++ b/DEHPMatlab/ViewModel/Row/MatlabWorkspaceRowViewModel.cs
@@ -401,6 +401,11 @@ namespace DEHPMatlab.ViewModel.Row
             var result = (this.SelectedParameter != null || this.SelectedParameterType != null && this.SelectedParameter is null)
                          && (this.SelectedElementUsages.IsEmpty || this.SelectedElementDefinition != null && this.SelectedParameter != null);
 
+            if (this.SelectedParameterType is QuantityKind && this.SelectedScale is null)
+            {
+                result = false;
+            }
+
             this.IsVariableMappingValid = result ? this.IsParameterTypeValid() : default(bool?);
 
             return this.IsVariableMappingValid.HasValue && result && this.IsVariableMappingValid.Value;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-MATLAB/pulls) open
- [x] I have verified that I am following the DEHP-MATLAB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-MATLAB/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #40 
 - Only selected parameters are transferred
 - If an ElementDefinition is selected for the transfer, only transferable parameters are selected
 
<!-- Thanks for contributing to DEHP-MATLAB! -->