### PR TITLE
SFPT mapping configuration saved and loaded ; fixes #54

### DIFF
--- a/DEHPMatlab.Tests/DstController/DstControllerTestFixture.cs
+++ b/DEHPMatlab.Tests/DstController/DstControllerTestFixture.cs
@@ -483,6 +483,8 @@ namespace DEHPMatlab.Tests.DstController
                 }
             });
 
+            this.dstController.MatlabAllWorkspaceRowViewModels.Add(variableRowViewModels.Last());
+
             Assert.DoesNotThrow(() => this.dstController.LoadMapping());
         }
 

--- a/DEHPMatlab.Tests/ViewModel/Dialogs/DstMappingConfigurationDialogViewModelTestFixture.cs
+++ b/DEHPMatlab.Tests/ViewModel/Dialogs/DstMappingConfigurationDialogViewModelTestFixture.cs
@@ -240,8 +240,6 @@ namespace DEHPMatlab.Tests.ViewModel.Dialogs
                 SelectedParameterType = this.quantityKindParameterType,
             };
 
-            Assert.IsFalse(variable.IsValid());
-            variable.SelectedScale = this.scale;
             Assert.IsTrue(variable.IsValid());
 
             this.viewModel.Variables.Add(variable);

--- a/DEHPMatlab/Services/MappingConfiguration/ExternalIdentifier.cs
+++ b/DEHPMatlab/Services/MappingConfiguration/ExternalIdentifier.cs
@@ -25,10 +25,15 @@
 namespace DEHPMatlab.Services.MappingConfiguration
 {
     using System;
+    using System.Collections.Generic;
 
     using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
 
     using DEHPCommon.Enumerators;
+
+    using DEHPMatlab.Enumerator;
+    using DEHPMatlab.ViewModel.Row;
 
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
@@ -61,5 +66,31 @@ namespace DEHPMatlab.Services.MappingConfiguration
         /// </summary>
         [JsonConverter(typeof(StringEnumConverter))]
         public ParameterSwitchKind ParameterSwitchKind { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="RowColumnSelection"/> if applicable
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public RowColumnSelection RowColumnSelection { get; set; }
+
+        /// <summary>
+        /// Gets or sets the collection of <see cref="string"/> for the <see cref="SampledFunctionParameterParameterAssignementRowViewModel.Index"/> if applicable
+        /// </summary>
+        public List<string> SampledFunctionParameterParameterAssignementIndices { get; set; }
+
+        /// <summary>
+        /// Gets or sets the index of the <see cref="IParameterTypeAssignment"/> containing Time Tagged values
+        /// </summary>
+        public int? TimeTaggedIndex { get; set; }
+
+        /// <summary>
+        /// Gets or sets the asserts if the values has been averaged if applicable
+        /// </summary>
+        public bool IsAveraged { get; set; }
+
+        /// <summary>
+        /// Gets or sets the SelecteTimeStep value if applicable
+        /// </summary>
+        public double SelectedTimeStep { get; set; }
     }
 }

--- a/DEHPMatlab/Services/MappingConfiguration/MappingConfigurationService.cs
+++ b/DEHPMatlab/Services/MappingConfiguration/MappingConfigurationService.cs
@@ -31,6 +31,7 @@ namespace DEHPMatlab.Services.MappingConfiguration
 
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
 
     using CDP4Dal.Operations;
 
@@ -102,7 +103,7 @@ namespace DEHPMatlab.Services.MappingConfiguration
         /// <returns>A newly created <see cref="ExternalIdentifierMap" /></returns>
         public ExternalIdentifierMap CreateExternalIdentifierMap(string newName)
         {
-            return new ExternalIdentifierMap
+            return new()
             {
                 Name = newName,
                 ExternalToolName = DstController.ThisToolName,
@@ -112,7 +113,7 @@ namespace DEHPMatlab.Services.MappingConfiguration
         }
 
         /// <summary>
-        /// Adds one correspondance to the <see cref="MappingConfigurationService.ExternalIdentifierMap" />
+        /// Adds one correspondance to the <see cref="ExternalIdentifierMap" />
         /// </summary>
         /// <param name="internalId">The thing that <see cref="externalId" /> corresponds to</param>
         /// <param name="externalId">The external thing that <see cref="internalId" /> corresponds to</param>
@@ -127,7 +128,7 @@ namespace DEHPMatlab.Services.MappingConfiguration
         }
 
         /// <summary>
-        /// Adds one correspondence to the <see cref="MappingConfigurationService.ExternalIdentifierMap" />
+        /// Adds one correspondence to the <see cref="ExternalIdentifierMap" />
         /// </summary>
         /// <param name="internalId">The thing that <paramref name="externalIdentifier" /> corresponds to</param>
         /// <param name="externalIdentifier">The external thing that <see cref="internalId" /> corresponds to</param>
@@ -155,7 +156,7 @@ namespace DEHPMatlab.Services.MappingConfiguration
         }
 
         /// <summary>
-        /// Adds one correspondence to the <see cref="MappingConfigurationService.ExternalIdentifierMap" />
+        /// Adds one correspondence to the <see cref="ExternalIdentifierMap" />
         /// </summary>
         /// <param name="mappedElement">A <see cref="ParameterToMatlabVariableMappingRowViewModel" /></param>
         public void AddToExternalIdentifierMap(ParameterToMatlabVariableMappingRowViewModel mappedElement)
@@ -167,7 +168,11 @@ namespace DEHPMatlab.Services.MappingConfiguration
                 Identifier = mappedElement.SelectedMatlabVariable.Identifier,
                 MappingDirection = MappingDirection.FromHubToDst,
                 ValueIndex = index,
-                ParameterSwitchKind = switchKind
+                ParameterSwitchKind = switchKind,
+                RowColumnSelection = mappedElement.SelectedMatlabVariable.RowColumnSelectionToDst,
+                SampledFunctionParameterParameterAssignementIndices =
+                    mappedElement.SelectedMatlabVariable.SampledFunctionParameterParameterAssignementToDstRows
+                        .Select(x => x.Index).ToList()
             });
         }
 
@@ -182,9 +187,18 @@ namespace DEHPMatlab.Services.MappingConfiguration
         {
             foreach (var variable in parameterVariable)
             {
+                var timeTaggedParameter = variable.Value.SampledFunctionParameterParameterAssignementToHubRows
+                    .FirstOrDefault(x => x.IsTimeTaggedParameter);
+
                 this.AddToExternalIdentifierMap(variable.Key.Iid, new ExternalIdentifier
                 {
-                    Identifier = variable.Value.Identifier
+                    Identifier = variable.Value.Identifier,
+                    IsAveraged = variable.Value.IsAveraged,
+                    RowColumnSelection = variable.Value.RowColumnSelectionToHub,
+                    SelectedTimeStep = variable.Value.SelectedTimeStep,
+                    SampledFunctionParameterParameterAssignementIndices = variable.Value.SampledFunctionParameterParameterAssignementToHubRows
+                        .Select(x => x.Index).ToList(),
+                    TimeTaggedIndex = timeTaggedParameter == null ? null : variable.Value.SampledFunctionParameterParameterAssignementToHubRows.IndexOf(timeTaggedParameter)
                 });
 
                 if (variable.Key.GetContainerOfType<ElementUsage>() is { } elementUsage)
@@ -240,7 +254,7 @@ namespace DEHPMatlab.Services.MappingConfiguration
         }
 
         /// <summary>
-        /// Refreshes the <see cref="MappingConfigurationService.ExternalIdentifierMap" /> usually done after a session write
+        /// Refreshes the <see cref="ExternalIdentifierMap" /> usually done after a session write
         /// </summary>
         public void RefreshExternalIdentifierMap()
         {
@@ -330,15 +344,15 @@ namespace DEHPMatlab.Services.MappingConfiguration
             var mappedElements = new List<ParameterToMatlabVariableMappingRowViewModel>();
 
             foreach (var idCorrespondences in this.correspondences
-                         .Where(x => x.ExternalIdentifier.MappingDirection == MappingDirection.FromHubToDst)
-                         .GroupBy(x => x.ExternalIdentifier.Identifier))
+                .Where(x => x.ExternalIdentifier.MappingDirection == MappingDirection.FromHubToDst)
+                .GroupBy(x => x.ExternalIdentifier.Identifier))
             {
                 if (variables.FirstOrDefault(x => x.Identifier.Equals(idCorrespondences.Key)) is not { } element)
                 {
                     continue;
                 }
 
-                foreach (var (internalId, externalId, idCorrespondence) in idCorrespondences)
+                foreach (var (internalId, externalId, _) in idCorrespondences)
                 {
                     if (!this.hubController.GetThingById(internalId, this.hubController.OpenIteration, out ParameterValueSet valueSet))
                     {
@@ -349,6 +363,8 @@ namespace DEHPMatlab.Services.MappingConfiguration
                     {
                         continue;
                     }
+
+                    this.LoadSampledFunctionParameterTypeMappingConfiguration(element, externalId, valueSet);
 
                     var mappedElement = new ParameterToMatlabVariableMappingRowViewModel(valueSet, index, externalId.ParameterSwitchKind)
                     {
@@ -363,6 +379,44 @@ namespace DEHPMatlab.Services.MappingConfiguration
         }
 
         /// <summary>
+        /// If the current <see cref="valueSet" /> correspond to a ValueSet of a <see cref="Parameter" /> of type
+        /// <see cref="SampledFunctionParameterType" />,
+        /// loads the corresponding row/column correspondance mapping configuration
+        /// </summary>
+        /// <param name="element">The <see cref="MatlabWorkspaceRowViewModel" /></param>
+        /// <param name="externalId">The <see cref="ExternalIdentifier" /></param>
+        /// <param name="valueSet">The <see cref="ParameterValueSet" /></param>
+        private void LoadSampledFunctionParameterTypeMappingConfiguration(MatlabWorkspaceRowViewModel element, ExternalIdentifier externalId, ParameterValueSet valueSet)
+        {
+            if (valueSet.GetContainerOfType<ParameterOrOverrideBase>()?.ParameterType is SampledFunctionParameterType sampledFunctionParameterType)
+            {
+                element.RowColumnSelectionToDst = externalId.RowColumnSelection;
+                element.SampledFunctionParameterParameterAssignementToDstRows.Clear();
+                var parameterIndex = 0;
+
+                foreach (IndependentParameterTypeAssignment independentParameterTypeAssignment in sampledFunctionParameterType.IndependentParameterType)
+                {
+                    element.SampledFunctionParameterParameterAssignementToDstRows
+                        .Add(new SampledFunctionParameterParameterAssignementRowViewModel(
+                            externalId.SampledFunctionParameterParameterAssignementIndices[parameterIndex++])
+                        {
+                            SelectedParameterTypeAssignment = independentParameterTypeAssignment
+                        });
+                }
+
+                foreach (DependentParameterTypeAssignment dependentParameterTypeAssignment in sampledFunctionParameterType.DependentParameterType)
+                {
+                    element.SampledFunctionParameterParameterAssignementToDstRows
+                        .Add(new SampledFunctionParameterParameterAssignementRowViewModel(
+                            externalId.SampledFunctionParameterParameterAssignementIndices[parameterIndex++])
+                        {
+                            SelectedParameterTypeAssignment = dependentParameterTypeAssignment
+                        });
+                }
+            }
+        }
+
+        /// <summary>
         /// Maps the <see cref="MatlabWorkspaceRowViewModel" />s defined in the <see cref="ExternalIdentifierMap" />
         /// </summary>
         /// <param name="variables">The collection of <see cref="MatlabWorkspaceRowViewModel" /></param>
@@ -372,8 +426,8 @@ namespace DEHPMatlab.Services.MappingConfiguration
             var mappedVariables = new List<MatlabWorkspaceRowViewModel>();
 
             foreach (var idCorrespondences in this.correspondences
-                         .Where(x => x.ExternalIdentifier.MappingDirection == MappingDirection.FromDstToHub)
-                         .GroupBy(x => x.ExternalIdentifier.Identifier))
+                .Where(x => x.ExternalIdentifier.MappingDirection == MappingDirection.FromDstToHub)
+                .GroupBy(x => x.ExternalIdentifier.Identifier))
             {
                 if (variables.FirstOrDefault(x => x.Identifier.Equals(idCorrespondences.Key)) is not { } element)
                 {
@@ -385,10 +439,69 @@ namespace DEHPMatlab.Services.MappingConfiguration
                 element.MappingConfigurations.AddRange(this.ExternalIdentifierMap.Correspondence
                     .Where(x => idCorrespondences.Any(c => c.Iid == x.Iid)).ToList());
 
+                foreach (var (internalId, externalId, _) in idCorrespondences)
+                {
+                    if (!this.hubController.GetThingById(internalId, this.hubController.OpenIteration, out Thing thing))
+                    {
+                        continue;
+                    }
+
+                    if (thing is ParameterOrOverrideBase parameterOrOverride)
+                    {
+                        this.LoadSampledFunctionParameterTypeMappingConfiguration(element, externalId, parameterOrOverride);
+                    }
+                }
+
                 mappedVariables.Add(element);
             }
 
             return mappedVariables;
+        }
+
+        /// <summary>
+        /// If the current <see cref="parameterOrOverride" /> correspond to a <see cref="ParameterOrOverrideBase" /> of type
+        /// <see cref="SampledFunctionParameterType" />,
+        /// loads the corresponding row/column correspondance mapping configuration
+        /// </summary>
+        /// <param name="element">The <see cref="MatlabWorkspaceRowViewModel" /></param>
+        /// <param name="externalId">The <see cref="ExternalIdentifier" /></param>
+        /// <param name="parameterOrOverride">The <see cref="ParameterOrOverrideBase" /></param>
+        private void LoadSampledFunctionParameterTypeMappingConfiguration(MatlabWorkspaceRowViewModel element, ExternalIdentifier externalId, ParameterOrOverrideBase parameterOrOverride)
+        {
+            if (parameterOrOverride.ParameterType is SampledFunctionParameterType sampledFunctionParameterType)
+            {
+                element.RowColumnSelectionToHub = externalId.RowColumnSelection;
+                element.SampledFunctionParameterParameterAssignementToHubRows.Clear();
+                var parameterIndex = 0;
+
+                foreach (IndependentParameterTypeAssignment independentParameterTypeAssignment in sampledFunctionParameterType.IndependentParameterType)
+                {
+                    element.SampledFunctionParameterParameterAssignementToHubRows
+                        .Add(new SampledFunctionParameterParameterAssignementRowViewModel(
+                            externalId.SampledFunctionParameterParameterAssignementIndices[parameterIndex++])
+                        {
+                            SelectedParameterTypeAssignment = independentParameterTypeAssignment
+                        });
+                }
+
+                foreach (DependentParameterTypeAssignment dependentParameterTypeAssignment in sampledFunctionParameterType.DependentParameterType)
+                {
+                    element.SampledFunctionParameterParameterAssignementToHubRows
+                        .Add(new SampledFunctionParameterParameterAssignementRowViewModel(
+                            externalId.SampledFunctionParameterParameterAssignementIndices[parameterIndex++])
+                        {
+                            SelectedParameterTypeAssignment = dependentParameterTypeAssignment
+                        });
+                }
+
+                element.IsAveraged = externalId.IsAveraged;
+                element.SelectedTimeStep = externalId.SelectedTimeStep;
+
+                if (externalId.TimeTaggedIndex is not null)
+                {
+                    element.SampledFunctionParameterParameterAssignementToHubRows[externalId.TimeTaggedIndex.Value].IsTimeTaggedParameter = true;
+                }
+            }
         }
 
         /// <summary>

--- a/DEHPMatlab/Services/MappingConfiguration/MappingConfigurationService.cs
+++ b/DEHPMatlab/Services/MappingConfiguration/MappingConfigurationService.cs
@@ -416,47 +416,6 @@ namespace DEHPMatlab.Services.MappingConfiguration
             }
         }
 
-        /// <summary>
-        /// Maps the <see cref="MatlabWorkspaceRowViewModel" />s defined in the <see cref="ExternalIdentifierMap" />
-        /// </summary>
-        /// <param name="variables">The collection of <see cref="MatlabWorkspaceRowViewModel" /></param>
-        /// <returns>A collection of <see cref="MatlabWorkspaceRowViewModel" /></returns>
-        private List<MatlabWorkspaceRowViewModel> MapElementsFromTheExternalIdentifierMapToHub(IList<MatlabWorkspaceRowViewModel> variables)
-        {
-            var mappedVariables = new List<MatlabWorkspaceRowViewModel>();
-
-            foreach (var idCorrespondences in this.correspondences
-                .Where(x => x.ExternalIdentifier.MappingDirection == MappingDirection.FromDstToHub)
-                .GroupBy(x => x.ExternalIdentifier.Identifier))
-            {
-                if (variables.FirstOrDefault(x => x.Identifier.Equals(idCorrespondences.Key)) is not { } element)
-                {
-                    continue;
-                }
-
-                this.LoadCorrespondences(element, idCorrespondences);
-
-                element.MappingConfigurations.AddRange(this.ExternalIdentifierMap.Correspondence
-                    .Where(x => idCorrespondences.Any(c => c.Iid == x.Iid)).ToList());
-
-                foreach (var (internalId, externalId, _) in idCorrespondences)
-                {
-                    if (!this.hubController.GetThingById(internalId, this.hubController.OpenIteration, out Thing thing))
-                    {
-                        continue;
-                    }
-
-                    if (thing is ParameterOrOverrideBase parameterOrOverride)
-                    {
-                        this.LoadSampledFunctionParameterTypeMappingConfiguration(element, externalId, parameterOrOverride);
-                    }
-                }
-
-                mappedVariables.Add(element);
-            }
-
-            return mappedVariables;
-        }
 
         /// <summary>
         /// If the current <see cref="parameterOrOverride" /> correspond to a <see cref="ParameterOrOverrideBase" /> of type
@@ -502,6 +461,48 @@ namespace DEHPMatlab.Services.MappingConfiguration
                     element.SampledFunctionParameterParameterAssignementToHubRows[externalId.TimeTaggedIndex.Value].IsTimeTaggedParameter = true;
                 }
             }
+        }
+
+        /// <summary>
+        /// Maps the <see cref="MatlabWorkspaceRowViewModel" />s defined in the <see cref="ExternalIdentifierMap" />
+        /// </summary>
+        /// <param name="variables">The collection of <see cref="MatlabWorkspaceRowViewModel" /></param>
+        /// <returns>A collection of <see cref="MatlabWorkspaceRowViewModel" /></returns>
+        private List<MatlabWorkspaceRowViewModel> MapElementsFromTheExternalIdentifierMapToHub(IList<MatlabWorkspaceRowViewModel> variables)
+        {
+            var mappedVariables = new List<MatlabWorkspaceRowViewModel>();
+
+            foreach (var idCorrespondences in this.correspondences
+                .Where(x => x.ExternalIdentifier.MappingDirection == MappingDirection.FromDstToHub)
+                .GroupBy(x => x.ExternalIdentifier.Identifier))
+            {
+                if (variables.FirstOrDefault(x => x.Identifier.Equals(idCorrespondences.Key)) is not { } element)
+                {
+                    continue;
+                }
+
+                this.LoadCorrespondences(element, idCorrespondences);
+
+                element.MappingConfigurations.AddRange(this.ExternalIdentifierMap.Correspondence
+                    .Where(x => idCorrespondences.Any(c => c.Iid == x.Iid)).ToList());
+
+                foreach (var (internalId, externalId, _) in idCorrespondences)
+                {
+                    if (!this.hubController.GetThingById(internalId, this.hubController.OpenIteration, out Thing thing))
+                    {
+                        continue;
+                    }
+
+                    if (thing is ParameterOrOverrideBase parameterOrOverride)
+                    {
+                        this.LoadSampledFunctionParameterTypeMappingConfiguration(element, externalId, parameterOrOverride);
+                    }
+                }
+
+                mappedVariables.Add(element);
+            }
+
+            return mappedVariables;
         }
 
         /// <summary>

--- a/DEHPMatlab/ViewModel/MatlabTransferControlViewModel.cs
+++ b/DEHPMatlab/ViewModel/MatlabTransferControlViewModel.cs
@@ -186,7 +186,7 @@ namespace DEHPMatlab.ViewModel
             this.TransferInProgress = true;
             this.IsIndeterminate = true;
             this.statusBar.Append("Transfer in progress");
-
+            
             if (this.dstController.MappingDirection is MappingDirection.FromDstToHub)
             {
                 await this.dstController.TransferMappedThingsToHub();

--- a/DEHPMatlab/ViewModel/Row/MatlabWorkspaceRowViewModel.cs
+++ b/DEHPMatlab/ViewModel/Row/MatlabWorkspaceRowViewModel.cs
@@ -351,7 +351,6 @@ namespace DEHPMatlab.ViewModel.Row
             set => this.RaiseAndSetIfChanged(ref this.selectedParameterType, value);
         }
 
-
         /// <summary>
         /// The <see cref="RowColumnSelection" /> value for <see cref="MappingDirection.FromHubToDst" />
         /// </summary>
@@ -550,11 +549,6 @@ namespace DEHPMatlab.ViewModel.Row
         {
             var result = (this.SelectedParameter != null || this.SelectedParameterType != null && this.SelectedParameter is null)
                          && (this.SelectedElementUsages.IsEmpty || this.SelectedElementDefinition != null && this.SelectedParameter != null);
-
-            if (this.SelectedParameterType is QuantityKind && this.SelectedScale is null)
-            {
-                result = false;
-            }
 
             if (this.SelectedParameterType is SampledFunctionParameterType && this.TimeTaggedValues.Any())
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-MATLAB/pulls) open
- [x] I have verified that I am following the DEHP-MATLAB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-MATLAB/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #54 
The configuration of the SampledFunctionParameterType (Assignment for each IParameterTypeAssignment to a row/column and TimeTagged assertion) is saved and loaded inside the mapping configuration

<!-- Thanks for contributing to DEHP-MATLAB! -->