### PR TITLE
Mapping configuration and impact view bugs fix : Fixes #77 #78 #79

### DIFF
--- a/DEHPMatlab.Tests/DstController/DstControllerTestFixture.cs
+++ b/DEHPMatlab.Tests/DstController/DstControllerTestFixture.cs
@@ -405,7 +405,7 @@ namespace DEHPMatlab.Tests.DstController
                 x.Append(It.IsAny<Thing>(), It.IsAny<ChangeKind>()), Times.Exactly(5));
 
             this.exchangeHistory.Verify(x =>
-                x.Append(It.IsAny<ParameterValueSetBase>(), It.IsAny<IValueSet>()), Times.Exactly(2));
+                x.Append(It.IsAny<ParameterValueSetBase>(), It.IsAny<IValueSet>(), ParameterSwitchKind.COMPUTED), Times.Exactly(2));
 
             this.iteration.Relationship.Add(new BinaryRelationship()
             {

--- a/DEHPMatlab.Tests/DstController/DstControllerTestFixture.cs
+++ b/DEHPMatlab.Tests/DstController/DstControllerTestFixture.cs
@@ -295,7 +295,11 @@ namespace DEHPMatlab.Tests.DstController
 
             var parameter = new Parameter
             {
-                ParameterType = new SimpleQuantityKind(),
+                Iid = Guid.Empty,
+                ParameterType = new SimpleQuantityKind()
+                {
+                    Name = "Mass"
+                },
                 ValueSet =
                 {
                     new ParameterValueSet
@@ -303,16 +307,16 @@ namespace DEHPMatlab.Tests.DstController
                         Computed = new ValueArray<string>(new[] { "654321" }),
                         ValueSwitch = ParameterSwitchKind.COMPUTED
                     }
-                }
+                },
             };
 
-            var elementDefinition = new ElementDefinition
+            var elementDefinition = new ElementDefinition()
             {
-                Parameter =
-                {
-                    parameter
-                }
+                Iid = Guid.NewGuid(),
+                Name = "ElementDefinition"
             };
+
+            elementDefinition.Parameter.Add(parameter);
 
             this.dstController.SelectedDstMapResultToTransfer.Add(parameter);
 
@@ -334,8 +338,15 @@ namespace DEHPMatlab.Tests.DstController
 
             var param = new Parameter()
             {
-                ParameterType = new BooleanParameterType(),
+                Iid = Guid.NewGuid(),
+                ParameterType = new BooleanParameterType()
+                {
+                    Name = "Bool"
+                },
                 Container = new ElementDefinition()
+                {
+                    Name = "EL"
+                }
             };
 
             var variable = new MatlabWorkspaceRowViewModel("a", 0)

--- a/DEHPMatlab.Tests/MappingRules/ElementDefinitionToMatlabVariableRuleTestFixture.cs
+++ b/DEHPMatlab.Tests/MappingRules/ElementDefinitionToMatlabVariableRuleTestFixture.cs
@@ -134,7 +134,6 @@ namespace DEHPMatlab.Tests.MappingRules
                             }
                         }
                     },
-                    SelectedValue = new ValueSetValueRowViewModel(new ParameterValueSet(), "15", null)
                 }
             };
         }
@@ -150,7 +149,7 @@ namespace DEHPMatlab.Tests.MappingRules
             Assert.AreEqual(3, variables.Count);
             Assert.AreEqual("5", firstVariable.SelectedValue.Value);
             Assert.AreEqual(0.5d, initialMatlabVariables.First().ActualValue);
-            Assert.AreEqual("15", lastVariable.SelectedValue.Value);
+            Assert.AreEqual("-15", lastVariable.SelectedValue.Value);
             Assert.AreEqual(this.option1, lastVariable.SelectedOption);
             Assert.AreEqual(this.state2, lastVariable.SelectedState);
             Assert.AreNotEqual(this.option1, this.elements.First().SelectedMatlabVariable.SelectedOption);

--- a/DEHPMatlab.Tests/Services/MappingConfiguration/MappingConfigurationServiceTestFixture.cs
+++ b/DEHPMatlab.Tests/Services/MappingConfiguration/MappingConfigurationServiceTestFixture.cs
@@ -393,12 +393,25 @@ namespace DEHPMatlab.Tests.Services.MappingConfiguration
             this.mappingConfiguration.AddToExternalIdentifierMap(mappedElements.Last());
             Assert.AreEqual(3,this.mappingConfiguration.ExternalIdentifierMap.Correspondence.Count);
 
+            var option = new Option()
+            {
+                Iid = Guid.NewGuid()
+            };
+
+            var actualFiniteState = new ActualFiniteState()
+            {
+                Iid = Guid.NewGuid()
+            };
+
             this.mappingConfiguration.AddToExternalIdentifierMap(new Dictionary<ParameterOrOverrideBase, MatlabWorkspaceRowViewModel>()
             {
                 {
                     this.parameter, new MatlabWorkspaceRowViewModel("c", 45)
                     {
-                        Identifier = "c-b"
+                        Identifier = "c-b",
+                        SelectedScale = this.scale,
+                        SelectedOption = option,
+                        SelectedActualFiniteState = actualFiniteState
                     }
                 },
                 {
@@ -409,10 +422,10 @@ namespace DEHPMatlab.Tests.Services.MappingConfiguration
                 }
             });
 
-            Assert.AreEqual(7, this.mappingConfiguration.ExternalIdentifierMap.Correspondence.Count);
+            Assert.AreEqual(10, this.mappingConfiguration.ExternalIdentifierMap.Correspondence.Count);
 
             this.mappingConfiguration.AddToExternalIdentifierMap(internalId, "10N.h", MappingDirection.FromHubToDst);
-            Assert.AreEqual(8, this.mappingConfiguration.ExternalIdentifierMap.Correspondence.Count);
+            Assert.AreEqual(11, this.mappingConfiguration.ExternalIdentifierMap.Correspondence.Count);
 
             this.mappingConfiguration.ExternalIdentifierMap = new ExternalIdentifierMap()
             {
@@ -420,7 +433,7 @@ namespace DEHPMatlab.Tests.Services.MappingConfiguration
                 {
                     new IdCorrespondence(internalId, null, null)
                     {
-                        Iid = new Guid()
+                        Iid = Guid.NewGuid()
                     }
                 }
             };

--- a/DEHPMatlab.Tests/Services/MappingConfiguration/MappingConfigurationServiceTestFixture.cs
+++ b/DEHPMatlab.Tests/Services/MappingConfiguration/MappingConfigurationServiceTestFixture.cs
@@ -150,7 +150,13 @@ namespace DEHPMatlab.Tests.Services.MappingConfiguration
 
             variable.SampledFunctionParameterParameterAssignementToDstRows.AddRange(variable.SampledFunctionParameterParameterAssignementToHubRows);
 
-            this.parameterType = new SimpleQuantityKind(Guid.NewGuid(), null, null);
+            this.parameterType = new SimpleQuantityKind()
+            {
+                Iid = Guid.NewGuid(),
+                Name = "SimpleQuantityKind",
+                PossibleScale = { this.scale }
+            };
+
             this.person = new Person(Guid.NewGuid(), null, null) { GivenName = "test", DefaultDomain = this.domain };
 
             this.participant = new Participant(Guid.NewGuid(), null, null)
@@ -312,6 +318,7 @@ namespace DEHPMatlab.Tests.Services.MappingConfiguration
                     new IdCorrespondence() { InternalThing = Guid.NewGuid(), ExternalId = JsonConvert.SerializeObject(this.externalIdentifiers[2]) },
                     new IdCorrespondence() { InternalThing = this.parameterSampledFunctionParameter.Iid, ExternalId = JsonConvert.SerializeObject(this.externalIdentifiers[3]) },
                     new IdCorrespondence() { InternalThing = this.parameterSampledFunctionParameter.ValueSet.First().Iid, ExternalId = JsonConvert.SerializeObject(this.externalIdentifiers[4]) },
+                    new IdCorrespondence() { InternalThing = this.scale.Iid, ExternalId = JsonConvert.SerializeObject(this.externalIdentifiers[1]) },
                 }
             };
         }
@@ -438,7 +445,7 @@ namespace DEHPMatlab.Tests.Services.MappingConfiguration
 
             Assert.AreEqual(1, this.iteration.ExternalIdentifierMap.Count);
             transactionMock.Verify(x => x.CreateOrUpdate(It.IsAny<Thing>()), Times.Exactly(3));
-            transactionMock.Verify(x => x.Create(It.IsAny<Thing>(), null), Times.Exactly(5));
+            transactionMock.Verify(x => x.Create(It.IsAny<Thing>(), null), Times.Exactly(6));
         }
 
         [Test]
@@ -521,7 +528,7 @@ namespace DEHPMatlab.Tests.Services.MappingConfiguration
             Assert.IsNotNull(mappedVariables);
             Assert.AreEqual(2, mappedVariables.Count);
 
-            this.hubController.Verify(x => x.GetThingById(It.IsAny<Guid>(), It.IsAny<Iteration>(), out thing), Times.Exactly(13));
+            this.hubController.Verify(x => x.GetThingById(It.IsAny<Guid>(), It.IsAny<Iteration>(), out thing), Times.Exactly(19));
         }
 
         [Test]
@@ -541,7 +548,7 @@ namespace DEHPMatlab.Tests.Services.MappingConfiguration
 
             Assert.AreEqual(1, iterationClone.ExternalIdentifierMap.Count);
             transactionMock.Verify(x => x.CreateOrUpdate(It.IsAny<Thing>()), Times.Exactly(3));
-            transactionMock.Verify(x => x.Create(It.IsAny<Thing>(), null), Times.Exactly(5));
+            transactionMock.Verify(x => x.Create(It.IsAny<Thing>(), null), Times.Exactly(6));
         }
     }
 }

--- a/DEHPMatlab.Tests/ViewModel/Dialogs/DstMappingConfigurationDialogViewModelTestFixture.cs
+++ b/DEHPMatlab.Tests/ViewModel/Dialogs/DstMappingConfigurationDialogViewModelTestFixture.cs
@@ -349,6 +349,12 @@ namespace DEHPMatlab.Tests.ViewModel.Dialogs
 
             Assert.DoesNotThrow(() => this.viewModel.UpdateSelectedScale());
             Assert.AreEqual(this.scale, this.viewModel.SelectedThing.SelectedScale);
+
+            this.viewModel.SelectedThing.SelectedScale = new CyclicRatioScale();
+            Assert.DoesNotThrow(() => this.viewModel.UpdateAvailableScales());
+
+            this.viewModel.SelectedThing.SelectedScale = ratioScale;
+            Assert.DoesNotThrow(() => this.viewModel.UpdateAvailableScales());
         }
 
         [Test]

--- a/DEHPMatlab/DEHPMatlab.csproj
+++ b/DEHPMatlab/DEHPMatlab.csproj
@@ -19,7 +19,7 @@
     <None Remove="Resources\logo.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DEHPCommon" Version="1.0.247" />
+    <PackageReference Include="DEHPCommon" Version="1.0.267" />
     <PackageReference Include="IndexRange" Version="1.0.0" />
     <PackageReference Include="NLog" Version="4.6.8" />
     <PackageReference Include="reactiveui" Version="6.5.0" />

--- a/DEHPMatlab/DstController/DstController.cs
+++ b/DEHPMatlab/DstController/DstController.cs
@@ -699,23 +699,7 @@ namespace DEHPMatlab.DstController
 
                         foreach (var parameter in elementBasesToUpdate[element])
                         {
-                            var needToUpdateParameterIid = parameter.Iid == Guid.Empty;
-                            var sourceThing = this.CreateOrUpdateTransaction(transaction, (Parameter)parameter, elementClone.Parameter);
-                            this.VerifyRelationShip(transaction, iterationClone, parameter, sourceThing);
-
-                            if (!needToUpdateParameterIid)
-                            {
-                                continue;
-                            }
-
-                            foreach (var parameterVariable in this.ParameterVariable.Keys
-                                         .Where(x => x.ParameterType.Name == parameter.ParameterType.Name
-                                                     && x.Iid == Guid.Empty 
-                                                     && x.Container is ElementDefinition container 
-                                                     && container.Name == elementDefinition.Name).ToList())
-                            {
-                                parameterVariable.Iid = sourceThing.Iid;
-                            }
+                            this.AddParameterToTransaction(transaction, iterationClone, parameter, elementClone);
                         }
 
                         break;
@@ -734,6 +718,34 @@ namespace DEHPMatlab.DstController
                         break;
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Add a <see cref="Parameter"/> to the transaction and update its <see cref="Parameter.Iid"/> if needed
+        /// </summary>
+        /// <param name="transaction">The <see cref="IThingTransaction"/></param>
+        /// <param name="iterationClone">The <see cref="Iteration"/> clone</param>
+        /// <param name="parameter">The <see cref="Parameter"/></param>
+        /// <param name="elementClone">The <see cref="ElementDefinition"/> container of the <see cref="Parameter"/></param>
+        private void AddParameterToTransaction(IThingTransaction transaction, Iteration iterationClone, ParameterOrOverrideBase parameter, ElementDefinition elementClone)
+        {
+            var needToUpdateParameterIid = parameter.Iid == Guid.Empty;
+            var sourceThing = this.CreateOrUpdateTransaction(transaction, (Parameter)parameter, elementClone.Parameter);
+            this.VerifyRelationShip(transaction, iterationClone, parameter, sourceThing);
+
+            if (!needToUpdateParameterIid)
+            {
+                return;
+            }
+
+            foreach (var parameterVariable in this.ParameterVariable.Keys
+                         .Where(x => x.ParameterType.Name == parameter.ParameterType.Name
+                                     && x.Iid == Guid.Empty
+                                     && x.Container is ElementDefinition container
+                                     && container.Name == elementClone.Name).ToList())
+            {
+                parameterVariable.Iid = sourceThing.Iid;
             }
         }
 

--- a/DEHPMatlab/MappingRules/ElementDefinitionToMatlabVariableRule.cs
+++ b/DEHPMatlab/MappingRules/ElementDefinitionToMatlabVariableRule.cs
@@ -27,6 +27,10 @@ namespace DEHPMatlab.MappingRules
     using System.Collections.Generic;
     using System.Linq;
 
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
     using DEHPCommon.MappingEngine;
     using DEHPCommon.MappingRules.Core;
 
@@ -51,10 +55,26 @@ namespace DEHPMatlab.MappingRules
         {
             return input.Select(x =>
             {
+                x.SelectedValue = x.SelectedParameter.ParameterType is SampledFunctionParameterType or ArrayParameterType
+                    ? new ValueSetValueRowViewModel(x.SelectedParameter)
+                    : x.SelectedParameter.ValueSets.SelectMany(x => this.ComputesValueRow(x, x.ActualValue, null)).FirstOrDefault(); 
+
                 x.SelectedMatlabVariable = new MatlabWorkspaceRowViewModel(x.SelectedMatlabVariable);
 
                 return x;
             }).ToList();
+        }
+
+        /// <summary>
+        /// Computes the value row of one value array i.e. <see cref="IValueSet.Computed"/>
+        /// </summary>
+        /// <param name="valueSet">The <see cref="IValueSet"/> container</param>
+        /// <param name="values">The collection of values</param>
+        /// <param name="scale">The <see cref="MeasurementScale"/></param>
+        /// <returns></returns>
+        private IEnumerable<ValueSetValueRowViewModel> ComputesValueRow(IValueSet valueSet, ValueArray<string> values, MeasurementScale scale)
+        {
+            return values.Select(value => new ValueSetValueRowViewModel(valueSet, value, scale));
         }
     }
 }

--- a/DEHPMatlab/MappingRules/MatlabVariableToElementDefinitionRule.cs
+++ b/DEHPMatlab/MappingRules/MatlabVariableToElementDefinitionRule.cs
@@ -200,7 +200,6 @@ namespace DEHPMatlab.MappingRules
                         x.ParameterType.Iid == matlabVariable.SelectedParameterType.Iid) is { } parameter)
                 {
                     matlabVariable.SelectedParameter = parameter;
-                    matlabVariable.SelectedParameter.Scale = matlabVariable.SelectedScale;
                 }
                 else
                 {
@@ -224,6 +223,7 @@ namespace DEHPMatlab.MappingRules
                 }
             }
 
+            matlabVariable.SelectedParameter.Scale = matlabVariable.SelectedScale;
             this.UpdateValueSet(matlabVariable, matlabVariable.SelectedParameter);
             this.parameterNodeIdIdentifier[matlabVariable.SelectedParameter] = matlabVariable;
         }

--- a/DEHPMatlab/ViewModel/NetChangePreview/HubNetChangePreviewViewModel.cs
+++ b/DEHPMatlab/ViewModel/NetChangePreview/HubNetChangePreviewViewModel.cs
@@ -662,7 +662,7 @@ namespace DEHPMatlab.ViewModel.NetChangePreview
             {
                 var container = (ElementBase)parameterOrOverrideBase.Container;
 
-                var alreadyPresent = elementBases.Keys.FirstOrDefault(x => x.Iid == container.Iid);
+                var alreadyPresent = elementBases.Keys.FirstOrDefault(x => x.Iid == container.Iid && x.Name == container.Name);
 
                 if (alreadyPresent is null)
                 {

--- a/DEHPMatlab/Views/Dialogs/DstMappingConfigurationDialog.xaml
+++ b/DEHPMatlab/Views/Dialogs/DstMappingConfigurationDialog.xaml
@@ -38,7 +38,8 @@
             <GroupBox Grid.Row="0" x:Name="MainContainer" Header="Select Value Set To Map" Margin="10,10,10,10" Padding="10" Grid.ColumnSpan="2">
                 <dxg:TreeListControl ItemsSource="{Binding Variables}" SelectedItem="{Binding SelectedThing}">
                     <dxg:TreeListControl.View>
-                        <dxg:TreeListView Name="View" AllowEditing="False" AutoWidth="False" ExpandCollapseNodesOnNavigation="True" ExpandStateFieldName="IsExpanded" FixedLineWidth="0" HorizontalScrollbarVisibility="Auto"
+                        <dxg:TreeListView Name="View" AllowEditing="False" AutoWidth="False" ExpandCollapseNodesOnNavigation="True" 
+                                          ExpandStateFieldName="IsExpanded" FixedLineWidth="0" HorizontalScrollbarVisibility="Auto"
                                           NavigationStyle="Cell" ShowHorizontalLines="False" ShowIndicator="False" ShowVerticalLines="False" AllowSorting="True"
                                           TreeLineStyle="Solid" VerticalScrollbarVisibility="Auto">
                             <dxmvvm:Interaction.Behaviors>
@@ -239,7 +240,8 @@
                             </dxg:LookUpEdit>
                             <dxe:ComboBoxEdit Grid.Column="2" Margin="2" AllowNullInput="True" ApplyItemTemplateToSelectedItem="True" AutoComplete="True" ClearSelectionOnBackspace="True"
                                           DisplayMember="ShortName"
-                                          ItemsSource="{Binding SelectedThing.SelectedParameterType.AllPossibleScale}"
+                                          AllowUpdateTwoWayBoundPropertiesOnSynchronization="True"
+                                          ItemsSource="{Binding AvailableScales}"
                                           NullText="-" NullValueButtonPlacement="EditBox"
                                           SelectedItem="{Binding SelectedThing.SelectedScale}"
                                           ToolTip="Select a scale if the parameter type allows to do so"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-MATLAB/pulls) open
- [x] I have verified that I am following the DEHP-MATLAB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-MATLAB/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #77 #78  #79 

- Mapping configuration dialog does not auto-select ParameterType/Scale anymore 
- The Scale is correctly applied to each mapping
- The mapping to a new Parameter of an ElementDefinition is correctly saved on the mapping configuration
- Impact View shows all new ElementDefinition
<!-- Thanks for contributing to DEHP-MATLAB! -->