### PR TITLE
ParameterValueSwitch disable, string and bool detected : fix #84 #56

### DIFF
--- a/DEHPMatlab.Tests/DstController/DstControllerTestFixture.cs
+++ b/DEHPMatlab.Tests/DstController/DstControllerTestFixture.cs
@@ -191,7 +191,7 @@ namespace DEHPMatlab.Tests.DstController
             this.dstController.MatlabWorkspaceInputRowViewModels.Add(new MatlabWorkspaceRowViewModel("RE", 0.5));
             this.dstController.LoadScript(Path.Combine(TestContext.CurrentContext.TestDirectory, "Resources", "GNC_Lab4.m"));
             Assert.IsTrue(this.dstController.IsScriptLoaded);
-            Assert.AreEqual(82, this.dstController.MatlabWorkspaceInputRowViewModels.Count);
+            Assert.AreEqual(87, this.dstController.MatlabWorkspaceInputRowViewModels.Count);
 
             Assert.AreEqual(-6370, this.dstController.MatlabWorkspaceInputRowViewModels
                 .First(x => x.Name == "RE").ActualValue);
@@ -213,10 +213,14 @@ namespace DEHPMatlab.Tests.DstController
             this.dstController.MatlabAllWorkspaceRowViewModels.Add(this.dstController.MatlabWorkspaceInputRowViewModels[1]);
             this.dstController.MatlabWorkspaceInputRowViewModels[1].ActualValue = 0;
             Assert.IsTrue(string.IsNullOrEmpty(this.dstController.MatlabWorkspaceInputRowViewModels[1].ParentName));
+
+            var booleanVariable = this.dstController.MatlabAllWorkspaceRowViewModels.First(x => x.ActualValue is true);
+            booleanVariable.ActualValue = "false";
+            Assert.IsTrue(booleanVariable.ActualValue is false);
             this.matlabConnector.Verify(x => x.ExecuteFunction(It.IsAny<string>()), Times.Exactly(5));
 
             this.matlabConnector.Verify(x => x.PutVariable(It.IsAny<MatlabWorkspaceRowViewModel>()),
-                Times.Exactly(27));
+                Times.Exactly(34));
 
             Assert.DoesNotThrow(() => this.dstController.UnloadScript());
             Assert.IsTrue(string.IsNullOrEmpty(this.dstController.LoadedScriptName));

--- a/DEHPMatlab.Tests/Resources/GNC_Lab4.m
+++ b/DEHPMatlab.Tests/Resources/GNC_Lab4.m
@@ -1,6 +1,5 @@
 
 %% TASK 1
-
 % Constants 
 RE = - 6370;mu = 398600;h_A = 6000;h_B = 15000;
 
@@ -201,6 +200,12 @@ plot(t,a(3,:))
 xlabel('Time [s]')
 ylabel('a_z [m/s^2]')
 
+
+booleanTrue = true;
+booleanFalse = false;
+astring = "hello"
+aOtherstring = 'hello'
+emptyString = ''
 
 invalidUnaryPrefix = --TA;
 

--- a/DEHPMatlab.Tests/Services/MatlabParser/MatlabParserTestFixture.cs
+++ b/DEHPMatlab.Tests/Services/MatlabParser/MatlabParserTestFixture.cs
@@ -54,7 +54,7 @@ namespace DEHPMatlab.Tests.Services.MatlabParser
             var matlabWorkspaceViewModels = this.parser.ParseMatlabScript(Path.Combine(TestContext.CurrentContext.TestDirectory,
                 "Resources", "GNC_Lab4.m"), out modifiedScriptFilePath, out var duplicatedNodes );
 
-            Assert.AreEqual(20, matlabWorkspaceViewModels.Count);
+            Assert.AreEqual(25, matlabWorkspaceViewModels.Count);
             Assert.IsTrue((double)matlabWorkspaceViewModels.First().ActualValue < 0);
             Assert.AreEqual(-6370, matlabWorkspaceViewModels.First().ActualValue);
             Assert.IsTrue(File.Exists(modifiedScriptFilePath));

--- a/DEHPMatlab/DEHPMatlab.csproj
+++ b/DEHPMatlab/DEHPMatlab.csproj
@@ -19,7 +19,7 @@
     <None Remove="Resources\logo.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DEHPCommon" Version="1.0.267" />
+    <PackageReference Include="DEHPCommon" Version="1.0.274" />
     <PackageReference Include="IndexRange" Version="1.0.0" />
     <PackageReference Include="NLog" Version="4.6.8" />
     <PackageReference Include="reactiveui" Version="6.5.0" />

--- a/DEHPMatlab/DstController/DstController.cs
+++ b/DEHPMatlab/DstController/DstController.cs
@@ -1200,6 +1200,11 @@ namespace DEHPMatlab.DstController
                 sender.ActualValue = valueAsDouble;
             }
 
+            if (sender.ActualValue is not bool && bool.TryParse(sender.ActualValue.ToString(), out var valueAsBool))
+            {
+                sender.ActualValue = valueAsBool;
+            }
+
             if (string.IsNullOrEmpty(sender.ParentName))
             {
                 this.matlabConnector.PutVariable(sender);

--- a/DEHPMatlab/Views/Dialogs/HubMappingConfigurationDialog.xaml
+++ b/DEHPMatlab/Views/Dialogs/HubMappingConfigurationDialog.xaml
@@ -141,17 +141,7 @@
                                         <dxg:TreeListColumn Width="45" FieldName="OwnerShortName" Header="Owner" />
                                         <dxg:TreeListColumn FieldName="Published" Header="Published Value" />
                                         <dxg:TreeListColumn FieldName="ScaleShortName" Header="Scale" />
-                                        <dxg:TreeListColumn AllowEditing="True" FieldName="Switch">
-                                            <dxg:ColumnBase.CellTemplate>
-                                                <DataTemplate>
-                                                    <dxe:ComboBoxEdit Name="PART_Editor" IsTextEditable="False" ShowBorder="true" ShowCustomItems="False">
-                                                        <dxmvvm:Interaction.Behaviors>
-                                                            <dxmvvm:EnumItemsSourceBehavior EnumType="{x:Type engineeringModelData:ParameterSwitchKind}" />
-                                                        </dxmvvm:Interaction.Behaviors>
-                                                    </dxe:ComboBoxEdit>
-                                                </DataTemplate>
-                                            </dxg:ColumnBase.CellTemplate>
-                                        </dxg:TreeListColumn>
+                                        <dxg:TreeListColumn AllowEditing="False" FieldName="Switch" />
                                         <dxg:TreeListColumn FieldName="Computed" />
                                         <dxg:TreeListColumn AllowEditing="False" FieldName="Manual" />
                                         <dxg:TreeListColumn AllowEditing="False" FieldName="Reference" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-MATLAB/pulls) open
- [x] I have verified that I am following the DEHP-MATLAB [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-MATLAB/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #84  #56 

- All ParameterValueSwitch are on readonly mode
- Detection of boolean and string input added inside Matlab script
<!-- Thanks for contributing to DEHP-MATLAB! -->